### PR TITLE
Fix return in generic impl Handlers

### DIFF
--- a/macros/src/actix/mod.rs
+++ b/macros/src/actix/mod.rs
@@ -63,7 +63,9 @@ pub fn emit_v2_operation(input: TokenStream) -> TokenStream {
         item_ast.block = Box::new(
             syn::parse2(quote!(
                 {
-                    let f = #block;
+                    let f = (|| {
+                        #block
+                    })();
                     #w(f)
                 }
             ))


### PR DESCRIPTION
If one uses the return keyword in a handler returning the generic `impl Responder` or `Future`, the code generated by the procedural macro falls apart, because the return bypasses the wrapper.

```rust
#[api_v2_operation]
fn test(body: web::Json<InputStruct>) -> impl Responder {
    if check_input(&body) {
        return HttpResponse::BadRequest();
    };

    do_work();

    HttpResponse::Ok()
}
```

The correct way to go about this would probably be to find every return statement and wrap it individually as well, but wrapping the block in a lambda makes it hygienic enough that returns work.

This change shouldn't break anything i think.