### PR TITLE
[#106] Support uuid format with feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ actix-service = "0.4.1"
 actix-web = "1.0.4"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
+uuid = { version = "0.7.4", features = ["serde"] }
 
 [features]
 actix = ["paperclip-macros/actix", "paperclip-actix"]
@@ -56,6 +57,7 @@ v2 = ["paperclip-macros/v2", "paperclip-core/v2"]
 codegen = ["heck", "lazy_static", "regex", "tinytemplate", "paperclip-core/codegen"]
 cli = ["default", "env_logger", "structopt", "git2", "reqwest"]
 # codegen-fmt = ["codegen", "rustfmt-nightly"]
+uid = ["paperclip-core/uid"]
 
 [workspace]
 members = [

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ build:
 	cargo build --features default
 	cargo build --features actix
 	cargo build --features cli
+	cargo build --features uid
 	cargo build --all --all-features
 
 test:

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,7 @@ parking_lot = "0.9"
 regex = "1.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
+uuid = {version = "0", optional = true}
 
 [features]
 actix = ["default", "actix-http", "actix-web", "futures"]
@@ -31,3 +32,4 @@ datetime = ["chrono"]
 default = ["v2", "codegen"]
 v2 = ["paperclip-macros/v2"]
 codegen = ["heck"]
+uid = ["uuid"]

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -151,6 +151,9 @@ impl_type_simple!(
     DataTypeFormat::DateTime
 );
 
+#[cfg(feature = "uid")]
+impl_type_simple!(uuid::Uuid, DataType::String, DataTypeFormat::Uuid);
+
 /// Represents a OpenAPI v2 schema convertible. This is auto-implemented by
 /// [`api_v2_schema`](https://paperclip.waffles.space/paperclip_actix_macros/attr.api_v2_schema.html) macro.
 ///

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -38,6 +38,7 @@ struct Pet {
     class: PetClass,
     id: Option<u64>,
     updated: chrono::NaiveDateTime,
+    uid: Option<uuid::Uuid>,
 }
 
 #[test]
@@ -96,6 +97,10 @@ fn test_simple_app() {
                         },
                         "updated": {
                           "format": "date-time",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "format": "uuid",
                           "type": "string"
                         }
                       },
@@ -515,6 +520,10 @@ fn test_list_in_out() {
                         "updated": {
                           "format": "date-time",
                           "type": "string"
+                        },
+                        "uid": {
+                          "format": "uuid",
+                          "type": "string"
                         }
                       },
                       "required":["class", "name", "updated"]
@@ -615,6 +624,10 @@ fn test_impl_traits() {
                         },
                         "updated": {
                           "format": "date-time",
+                          "type": "string"
+                        },
+                        "uid": {
+                          "format": "uuid",
                           "type": "string"
                         }
                       },


### PR DESCRIPTION
This PR Resolves #106 
- Adds `uuid = 0` (with `optional = true`) in Cargo.toml of core crate.
- Adds `uuid` with `serde` enabled  in Cargo.toml of root crate.
- Add a new feature named `uid` = `[uuid]` to Cargo.toml core crate & `uid = ["paperclip-core/uid"]` in root Cargo.toml
- Add an implementation for `uuid::Uuid` format
- Updates tests