### PR TITLE
[#35] Use deprecated field for operations

### DIFF
--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -506,6 +506,8 @@ pub struct Operation<S> {
     pub responses: BTreeMap<String, Response<S>>,
     #[serde(default = "Vec::default", skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<Parameter<S>>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub deprecated: bool,
 }
 
 impl<S> Operation<S> {

--- a/src/v2/codegen/emitter.rs
+++ b/src/v2/codegen/emitter.rs
@@ -873,6 +873,7 @@ where
                 listable: false,
                 id: op.operation_id.clone(),
                 description: op.description.clone(),
+                deprecated: op.deprecated,
                 params,
                 response_contains_any,
                 body_required: true,
@@ -983,6 +984,7 @@ where
             OpRequirement {
                 id: op.operation_id.clone(),
                 description: op.description.clone(),
+                deprecated: op.deprecated,
                 params,
                 body_required: false,
                 listable,

--- a/src/v2/codegen/impls.rs
+++ b/src/v2/codegen/impls.rs
@@ -58,6 +58,7 @@ impl ApiObject {
                         description: req.description.as_ref().map(String::as_str),
                         object: &self.name,
                         op_id: req.id.as_ref().map(String::as_str),
+                        deprecated: req.deprecated,
                         method: Some(method),
                         body_required: req.body_required,
                         encoding: req.encoding.as_ref(),
@@ -202,6 +203,10 @@ impl<'a> ApiObjectImpl<'a> {
             let has_fields = builder.has_atleast_one_field();
             if builder.description.is_none() {
                 temp.write_str("\n")?;
+            }
+
+            if builder.deprecated {
+                temp.write_str("    #[deprecated]\n")?;
             }
 
             // All builder constructor functions are inlined.

--- a/src/v2/codegen/object.rs
+++ b/src/v2/codegen/object.rs
@@ -56,6 +56,8 @@ pub struct OpRequirement {
     pub id: Option<String>,
     /// Description of this operation (if any), to be used for docs.
     pub description: Option<String>,
+    /// Whether the operation is deprecated or not.
+    pub deprecated: bool,
     /// Parameters required for this operation.
     pub params: Vec<Parameter>,
     /// Whether the object itself is required (in body) for this operation.
@@ -228,6 +230,8 @@ pub(super) struct ApiObjectBuilder<'a> {
     pub helper_module_prefix: &'a str,
     /// Operation ID, if any.
     pub op_id: Option<&'a str>,
+    /// Whether the operation is deprecated or not.
+    pub deprecated: bool,
     /// HTTP method for the operation - all builders (other than object builders)
     /// have this.
     pub method: Option<HttpMethod>,

--- a/tests/pet-v2.yaml
+++ b/tests/pet-v2.yaml
@@ -150,6 +150,7 @@ paths:
     post:
       description: Create shipment for order
       operationID: createShipment
+      deprecated: true
       parameters:
       - in: body
         name: body

--- a/tests/test_codegen.rs
+++ b/tests/test_codegen.rs
@@ -463,6 +463,7 @@ impl PostShipmentsBody {
     }
 
     /// Create shipment for order
+    #[deprecated]
     #[inline]
     pub fn post() -> PostShipmentsBodyPostBuilder {
         PostShipmentsBodyPostBuilder {


### PR DESCRIPTION
This PR Resolves #35 
-  Adds `deprecated` field to `Operation`, `OpRequirement`
-  Adds generation of `[#deprecated]` attribute in builder, if 'deprecation` value present