### PR TITLE
Updated actix-web to 2.0, updated futures to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ tinytemplate = { version = "1.0", optional = true }
 url = "1.7"
 
 [dev-dependencies]
-actix-rt = "0.2.3"
-actix-service = "0.4.1"
-actix-web = "1.0.4"
+actix-rt = "1.0"
+actix-service = "1.0"
+actix-web = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
-futures = "0.1"
+futures = "0.3"
 uuid = { version = "0.8", features = ["serde"] }
 
 [features]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,11 +10,10 @@ homepage = "https://github.com/wafflespeanut/paperclip"
 repository = "https://github.com/wafflespeanut/paperclip"
 
 [dependencies]
-actix-web = { version = "1.0.4", optional = true }
-actix-http = { version = "0.2.6", optional = true }
+actix-web = { version = "2.0", optional = true }
+actix-http = { version = "1.0", optional = true }
 chrono = { version = "0", optional = true }
 failure = "0.1"
-futures = { version = "0.1", optional = true }
 heck = { version = "0.3", optional = true }
 lazy_static = "1.3"
 log = "0.4"
@@ -29,7 +28,7 @@ serde_yaml = "0.8"
 uuid = { version = "0", optional = true }
 
 [features]
-actix = ["v2", "actix-http", "actix-web", "futures"]
+actix = ["v2", "actix-http", "actix-web"]
 datetime = ["chrono"]
 decimal = ["rust_decimal"]
 default = ["v2", "codegen"]

--- a/core/src/v2/mod.rs
+++ b/core/src/v2/mod.rs
@@ -10,7 +10,7 @@ mod resolver;
 pub mod schema;
 
 #[cfg(feature = "actix")]
-pub use self::actix::{FutureWrapper, ResponderWrapper};
+pub use self::actix::ResponderWrapper;
 
 pub use self::models::{DefaultSchema, ResolvableApi};
 pub use self::schema::Schema;

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -334,7 +334,7 @@ impl_schema_map!(BTreeMap<K, V>);
 ///
 /// **NOTE:** The type parameters specified here aren't used by the trait itself,
 /// but *can* be used for constraining stuff in framework-related impls.
-pub trait Apiv2Operation<T, R, U> {
+pub trait Apiv2Operation<T, R> {
     /// Returns the definition for this operation.
     fn operation() -> DefaultOperationRaw;
 

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -334,7 +334,7 @@ impl_schema_map!(BTreeMap<K, V>);
 ///
 /// **NOTE:** The type parameters specified here aren't used by the trait itself,
 /// but *can* be used for constraining stuff in framework-related impls.
-pub trait Apiv2Operation<T, R> {
+pub trait Apiv2Operation<T, R, U> {
     /// Returns the definition for this operation.
     fn operation() -> DefaultOperationRaw;
 

--- a/plugins/actix-web/Cargo.toml
+++ b/plugins/actix-web/Cargo.toml
@@ -10,9 +10,9 @@ homepage = "https://github.com/wafflespeanut/paperclip"
 repository = "https://github.com/wafflespeanut/paperclip"
 
 [dependencies]
-futures = "0.1"
-actix-service = "0.4.1"
-actix-web = "1.0.4"
+futures = "0.3"
+actix-service = "1.0"
+actix-web = "2.0"
 lazy_static = "1.3"
 paperclip-core = { path = "../../core", version = "0.1.0", features = ["actix"] }
 paperclip-macros = { path = "../../macros", version = "0.2.0", features = ["actix"] }

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -263,7 +263,9 @@ where
 #[derive(Clone)]
 struct SpecHandler(Arc<RwLock<DefaultApiRaw>>);
 
-impl actix_web::dev::Factory<(), Ready<Result<HttpResponse, Error>>, Result<HttpResponse, Error>> for SpecHandler {
+impl actix_web::dev::Factory<(), Ready<Result<HttpResponse, Error>>, Result<HttpResponse, Error>>
+    for SpecHandler
+{
     fn call(&self, _: ()) -> Ready<Result<HttpResponse, Error>> {
         fut_ok(HttpResponse::Ok().json(&*self.0.read()))
     }

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -135,14 +135,6 @@ where
         self
     }
 
-    /// Proxy for [`actix_web::App::hostname`](https://docs.rs/actix-web/*/actix_web/struct.App.html#method.hostname).
-    ///
-    /// **NOTE:** This doesn't affect spec generation.
-    // pub fn hostname(mut self, val: &str) -> Self {
-    //     self.inner = self.inner.hostname(val);
-    //     self
-    // }
-
     /// Proxy for [`actix_web::App::default_service`](https://docs.rs/actix-web/*/actix_web/struct.App.html#method.default_service).
     ///
     /// **NOTE:** This doesn't affect spec generation.

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -1,15 +1,14 @@
 //! Proxy module for [`actix_web::web`](https://docs.rs/actix-web/*/actix_web/web/index.html).
 
 pub use actix_web::web::{
-    block, service, to, Bytes, BytesMut, Data, Form, FormConfig, HttpRequest,
-    HttpResponse, Json, JsonConfig, Path, PathConfig, Payload, PayloadConfig, Query, QueryConfig,
+    block, service, to, Bytes, BytesMut, Data, Form, FormConfig, HttpRequest, HttpResponse, Json,
+    JsonConfig, Path, PathConfig, Payload, PayloadConfig, Query, QueryConfig,
 };
 
 use crate::Mountable;
 use actix_service::ServiceFactory;
 use actix_web::dev::{
-    AppService, Factory, HttpServiceFactory, ServiceRequest, ServiceResponse,
-    Transform,
+    AppService, Factory, HttpServiceFactory, ServiceRequest, ServiceResponse, Transform,
 };
 use actix_web::guard::Guard;
 use actix_web::{http::Method, Error, FromRequest, Responder};
@@ -145,7 +144,7 @@ where
     /// Wrapper for [`actix_web::Resource::to`](https://docs.rs/actix-web/*/actix_web/struct.Resource.html#method.to).
     pub fn to<F, I, R, U>(mut self, handler: F) -> Self
     where
-        F: Apiv2Operation<I, R, U> + Factory<I, R, U> + 'static,
+        F: Apiv2Operation<I, U> + Factory<I, R, U> + 'static,
         I: FromRequest + 'static,
         R: Future<Output = U> + 'static,
         U: Responder + 'static,
@@ -154,20 +153,6 @@ where
         self.inner = self.inner.to(handler);
         self
     }
-
-    /// Wrapper for [`actix_web::Resource::to_async`](https://docs.rs/actix-web/*/actix_web/struct.Resource.html#method.to_async).
-    // #[allow(clippy::wrong_self_convention)]
-    // pub fn to_async<F, I, R>(mut self, handler: F) -> Self
-    // where
-    //     F: Apiv2Operation<I, R> + Factory<I, _, R> + 'static,
-    //     I: FromRequest + 'static,
-    //     R: Future + 'static,
-    //     R::Output: Responder,
-    // {
-    //     self.update_from_handler::<F, I, R>();
-    //     self.inner = self.inner.to_async(handler);
-    //     self
-    // }
 
     /// Proxy for [`actix_web::web::Resource::wrap`](https://docs.rs/actix-web/*/actix_web/struct.Resource.html#method.wrap).
     ///
@@ -254,7 +239,7 @@ where
     /// Updates this resource using the given handler.
     fn update_from_handler<F, I, R, U>(&mut self)
     where
-        F: Apiv2Operation<I, R, U>,
+        F: Apiv2Operation<I, U>,
     {
         let mut op = F::operation();
         op.set_parameter_names_from_path_template(&self.path);
@@ -547,7 +532,7 @@ impl Route {
     /// Wrapper for [`actix_web::Route::to`](https://docs.rs/actix-web/*/actix_web/struct.Route.html#method.to)
     pub fn to<F, I, R, U>(mut self, handler: F) -> Self
     where
-        F: Apiv2Operation<I, R, U> + Factory<I, R, U>,
+        F: Apiv2Operation<I, U> + Factory<I, R, U>,
         I: FromRequest + 'static,
         R: Future<Output = U> + 'static,
         U: Responder + 'static,

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -6,7 +6,7 @@ pub use actix_web::web::{
 };
 
 use crate::Mountable;
-use actix_service::ServiceFactory;
+use actix_service::{IntoServiceFactory, ServiceFactory};
 use actix_web::dev::{
     AppService, Factory, HttpServiceFactory, ServiceRequest, ServiceResponse, Transform,
 };
@@ -69,7 +69,7 @@ where
     }
 }
 
-impl<T> actix_service::IntoServiceFactory<T> for Resource<actix_web::Resource<T>>
+impl<T> IntoServiceFactory<T> for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
             Config = (),
@@ -138,6 +138,15 @@ where
     /// **NOTE:** This doesn't affect spec generation.
     pub fn data<U: 'static>(mut self, data: U) -> Self {
         self.inner = self.inner.data(data);
+        self
+    }
+
+    /// Proxy for [`actix_web::Resource::app_data`](https://docs.rs/actix-web/*/actix_web/struct.Resource.html#method.app_data).
+    ///
+    /// **NOTE:** This doesn't affect spec generation.
+    pub fn app_data<U: 'static>(mut self, data: U) -> Self {
+        let w = self.inner.app_data(data);
+        self.inner = w;
         self
     }
 
@@ -542,22 +551,6 @@ impl Route {
         self.inner = self.inner.to(handler);
         self
     }
-
-    // /// Wrapper for [`actix_web::Route::to_async`](https://docs.rs/actix-web/*/actix_web/struct.Route.html#method.to_async)
-    // #[allow(clippy::wrong_self_convention)]
-    // pub fn to_async<F, I, R>(mut self, handler: F) -> Self
-    // where
-    //     F: Apiv2Operation<I, R> + AsyncFactory<I, R> + 'static,
-    //     I: FromRequest + 'static,
-    //     R: IntoFuture + 'static,
-    //     R::Item: Responder,
-    //     R::Error: Into<Error>,
-    // {
-    //     self.operation = Some(F::operation());
-    //     self.definitions = F::definitions();
-    //     self.inner = self.inner.to_async(handler);
-    //     self
-    // }
 }
 
 /// Wrapper for [`actix_web::web::method`](https://docs.rs/actix-web/*/actix_web/web/fn.method.html).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,5 @@ pub mod actix {
 
     pub use paperclip_actix::{api_v2_operation, api_v2_schema};
     pub use paperclip_actix::{web, App, Mountable, OpenApiExt};
-    pub use paperclip_core::v2::{FutureWrapper, ResponderWrapper};
+    pub use paperclip_core::v2::ResponderWrapper;
 }

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -703,7 +703,7 @@ fn test_impl_traits() {
         }
     }
 
-    /// TODO: Returning impl Responder will not output any schema schema. How to tell what really function returns?
+    /// TODO: Returning impl Responder will not output any schema. How to tell what really function returns?
     #[api_v2_operation]
     async fn get_pet_async() -> impl Responder {
         Pet::default()


### PR DESCRIPTION
I've updated versions of all actix libs and futures lib.

It worked for one of my project but I'm not sure if I've done all this properly. I'll have to do more testing (two another projects awaits), but I'm creating this PR as a draft so someone else can take a look at it to maybe spot something.

As far as i noticed this won't compile with actix-web openssl feature (happily it works with rustls)
Also I couldn't manage to wrap async/await handler with api_v2_operation macro, I'll investigate it shortly.