### PR TITLE
Added api_v2_errors

### DIFF
--- a/book/actix-plugin.md
+++ b/book/actix-plugin.md
@@ -158,51 +158,19 @@ Similarly, if we were to use other extractors like `web::Query<T>`, `web::Form<T
 
 #### Manually defining additional response codes
 
-There is a macro `api_v2_errors` which helps to manually add responses other than 200. Here is an example.
-We define an enum that represents the error. To use it in actix-web it needs to implement `Display` and `ResponseError`.
-There is no need to impl Display by hand for such simple enums - we can use `enum-display-derive` lib.
+There is a macro `api_v2_errors` which helps to manually add responses other than 200.
 
 ```rust
-use actix_web::{
-    error::{ErrorInternalServerError, ErrorUnauthorized, ResponseError},
-    HttpResponse,
-};
-use enum_display_derive::Display;
 use paperclip::actix::api_v2_errors;
-use std::fmt::Display;
 
 #[api_v2_errors(
-    "400 Bad Request",
-    "401 Unauthorized: Can't read session from header",
-    "500 Internal Server Error",
+    code=400,
+    code=401, description="Unauthorized: Can't read session from header",
+    code=500,
 )]
-#[derive(Debug, Display)]
-pub enum UserError {
-    Unauth,
-    Internal(String),
+pub enum MyError {
+    /* ... */
 }
-
-impl ResponseError for UserError {
-    fn error_response(&self) -> HttpResponse {
-        match self {
-            Self::Unauth =>
-              HttpResponse::from_error(
-                  ErrorUnauthorized("Unauthorized: Can't read session from header")
-              ),
-            Self::Internal(msg) =>
-              HttpResponse::from_error(
-                  ErrorInternalServerError(msg.clone())
-              ),
-        }
-    }
-}
-```
-
-Such enum can then be used in handler return type to have defined response codes added to this handler docs:
-
-```rust
-#[api_v2_operation]
-async fn my_handler() -> Result<Pet, UserError> { Err(UserError::Internal("Some error")) }
 ```
 
 #### Known limitations

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -341,3 +341,11 @@ pub trait Apiv2Operation<T, R> {
     /// Returns the definitions used by this operation.
     fn definitions() -> BTreeMap<String, DefaultSchemaRaw>;
 }
+
+/// Represents a OpenAPI v2 error convertible. This is auto-implemented by
+/// [`api_v2_errors`](https://paperclip.waffles.space/paperclip_actix_macros/attr.api_v2_errors.html) macro.
+///
+/// This is implemented for primitive types by default.
+pub trait Apiv2Errors {
+    const ERROR_MAP: &'static [(&'static str, &'static str)];
+}

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -344,8 +344,6 @@ pub trait Apiv2Operation<T, R> {
 
 /// Represents a OpenAPI v2 error convertible. This is auto-implemented by
 /// [`api_v2_errors`](https://paperclip.waffles.space/paperclip_actix_macros/attr.api_v2_errors.html) macro.
-///
-/// This is implemented for primitive types by default.
 pub trait Apiv2Errors {
-    const ERROR_MAP: &'static [(&'static str, &'static str)];
+    const ERROR_MAP: &'static [(u16, &'static str)];
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,11 +17,12 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 heck = { version = "0.3", optional = true }
+http = { version = "0.2", optional = true }
 lazy_static = { version = "1.3", optional = true }
 strum = "0.17"
 strum_macros = "0.17"
 
 [features]
-actix = ["heck", "lazy_static"]
+actix = ["heck", "http", "lazy_static"]
 default = ["v2"]
 v2 = []

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -49,6 +49,12 @@ pub fn api_v2_schema(attrs: TokenStream, input: TokenStream) -> TokenStream {
     self::actix::emit_v2_definition(attrs, input)
 }
 
+#[cfg(feature = "actix")]
+#[proc_macro_attribute]
+pub fn api_v2_errors(attrs: TokenStream, input: TokenStream) -> TokenStream {
+    self::actix::emit_v2_errors(attrs, input)
+}
+
 /// Generate an error at the call site and return empty token stream.
 fn span_error_with_msg<T: Spanned>(it: &T, msg: &str) -> TokenStream {
     it.span().unwrap().error(msg).emit();

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod web;
 
 pub use self::web::{Resource, Route, Scope};
-pub use paperclip_macros::{api_v2_operation, api_v2_schema};
+pub use paperclip_macros::{api_v2_errors, api_v2_operation, api_v2_schema};
 
 use self::web::{RouteWrapper, ServiceConfig};
 use actix_service::ServiceFactory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use paperclip_macros::api_v2_schema_struct as api_v2_schema;
 pub mod actix {
     //! Plugin types, traits and macros for actix-web framework.
 
-    pub use paperclip_actix::{api_v2_operation, api_v2_schema};
+    pub use paperclip_actix::{api_v2_errors, api_v2_operation, api_v2_schema};
     pub use paperclip_actix::{web, App, Mountable, OpenApiExt};
     pub use paperclip_core::v2::ResponderWrapper;
 }

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -975,7 +975,14 @@ fn test_errors_app() {
     };
     use std::fmt;
 
-    #[api_v2_errors("400 Sorry, bad request", "403 Forbidden, go away")]
+    #[api_v2_errors(
+        400,
+        description = "Sorry, bad request",
+        code = 401,
+        code = 403,
+        description = "Forbidden, go away",
+        500
+    )]
     #[derive(Debug)]
     struct PetError {}
 
@@ -1064,8 +1071,14 @@ fn test_errors_app() {
                           "400": {
                             "description": "Sorry, bad request"
                           },
+                          "401": {
+                            "description": "Unauthorized"
+                          },
                           "403":{
                             "description":"Forbidden, go away"
+                          },
+                          "500": {
+                            "description": "Internal Server Error"
                           }
                         }
                       }

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -11,7 +11,7 @@ use actix_web::dev::{MessageBody, Payload, ServiceRequest, ServiceResponse};
 use actix_web::{App, Error, FromRequest, HttpRequest, HttpServer, Responder};
 use chrono;
 use futures::future::{ok as fut_ok, ready, Future, Ready};
-use paperclip::actix::{api_v2_operation, api_v2_schema, web, OpenApiExt};
+use paperclip::actix::{api_v2_errors, api_v2_operation, api_v2_schema, web, OpenApiExt};
 use parking_lot::Mutex;
 
 use std::collections::{BTreeMap, HashSet};
@@ -959,6 +959,117 @@ fn test_custom_extractor_empty_schema() {
                         "responses": {}
                       }
                     }
+                  },
+                  "swagger": "2.0"
+                }),
+            );
+        },
+    );
+}
+
+#[test]
+fn test_errors_app() {
+    use actix_web::{
+        error::{ErrorBadRequest, ResponseError},
+        HttpResponse,
+    };
+    use std::fmt;
+
+    #[api_v2_errors("400 Sorry, bad request", "403 Forbidden, go away")]
+    #[derive(Debug)]
+    struct PetError {}
+
+    impl fmt::Display for PetError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Bad Request")
+        }
+    }
+
+    impl ResponseError for PetError {
+        fn error_response(&self) -> HttpResponse {
+            HttpResponse::from_error(ErrorBadRequest("Bad Request"))
+        }
+    }
+
+    #[api_v2_operation]
+    async fn echo_pet_with_errors(body: web::Json<Pet>) -> Result<web::Json<Pet>, PetError> {
+        Ok(body)
+    }
+
+    fn config(cfg: &mut web::ServiceConfig) {
+        cfg.service(web::resource("/echo").route(web::post().to(echo_pet_with_errors)));
+    }
+
+    run_and_check_app(
+        || {
+            App::new()
+                .wrap_api()
+                .with_json_spec_at("/api/spec")
+                .service(web::scope("/api").configure(config))
+                .build()
+        },
+        |addr| {
+            let mut resp = CLIENT
+                .get(&format!("http://{}/api/spec", addr))
+                .send()
+                .expect("request failed?");
+
+            check_json(
+                &mut resp,
+                json!({
+                  "info":{"title":"","version":""},
+                  "definitions": {
+                    "Pet": {
+                      "properties": {
+                        "class": {
+                          "enum": ["dog", "cat", "other"],
+                          "type": "string"
+                        },
+                        "id": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "updatedOn": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "uuid": {
+                          "format": "uuid",
+                          "type": "string"
+                        }
+                      },
+                      "required":["class", "name"]
+                    }
+                  },
+                  "paths": {
+                    "/api/echo": {
+                      "parameters": [{
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Pet"
+                        }
+                      }],
+                      "post": {
+                        "responses": {
+                          "200": {
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          },
+                          "400": {
+                            "description": "Sorry, bad request"
+                          },
+                          "403":{
+                            "description":"Forbidden, go away"
+                          }
+                        }
+                      }
+                    },
                   },
                   "swagger": "2.0"
                 }),


### PR DESCRIPTION
I've added api_v2_errors macro which implements Apiv2Errors trait for selected struct - it can be then (afer implementing also ResponseError) used in handler return type (example added in tests) to document errors in swagger.

Additional implementation of OperationModifier on Result<T, E> where
T is OperationModifier and E is OprationErrorsModifier
allows to automatically add defined errocodes to swagger handler response.

I'll test it in my project if it will work smooth in following days, but meanwhile you could maybe take a look if this approach is good enough (it's not the best for sure :-))