### PR TITLE
Harden `paperclip` against other crates using the `kv_unstable` feature of `log`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ actix-web = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 uuid = { version = "0.8", features = ["serde"] }
+log = { version = "0.4", features = ["kv_unstable"] }
 
 [features]
 actix = ["paperclip-macros/actix", "paperclip-actix"]

--- a/src/v2/codegen/impls.rs
+++ b/src/v2/codegen/impls.rs
@@ -251,7 +251,7 @@ impl<'a> ApiObjectImpl<'a> {
                 f.write_str("body: Default::default(),")?;
             }
 
-            builder.struct_fields_iter().try_for_each(|field| {
+            builder.struct_fields_iter().try_for_each::<_, fmt::Result>(|field| {
                 if field.prop.is_required() {
                     f.write_str("\n            ")?;
                     if field.prop.is_parameter() {

--- a/src/v2/codegen/impls.rs
+++ b/src/v2/codegen/impls.rs
@@ -251,25 +251,27 @@ impl<'a> ApiObjectImpl<'a> {
                 f.write_str("body: Default::default(),")?;
             }
 
-            builder.struct_fields_iter().try_for_each::<_, fmt::Result>(|field| {
-                if field.prop.is_required() {
-                    f.write_str("\n            ")?;
-                    if field.prop.is_parameter() {
-                        f.write_str("_param")?;
+            builder
+                .struct_fields_iter()
+                .try_for_each::<_, fmt::Result>(|field| {
+                    if field.prop.is_required() {
+                        f.write_str("\n            ")?;
+                        if field.prop.is_parameter() {
+                            f.write_str("_param")?;
+                        }
+
+                        f.write_str("_")?;
+                        f.write_str(&field.name.to_snek_case())?;
+                        f.write_str(": core::marker::PhantomData,")?;
+                    // If we have a container, then we store parameters inside that.
+                    } else if field.prop.is_parameter() && !needs_container {
+                        f.write_str("\n            param_")?;
+                        f.write_str(&field.name.to_snek_case())?;
+                        f.write_str(": None,")?;
                     }
 
-                    f.write_str("_")?;
-                    f.write_str(&field.name.to_snek_case())?;
-                    f.write_str(": core::marker::PhantomData,")?;
-                // If we have a container, then we store parameters inside that.
-                } else if field.prop.is_parameter() && !needs_container {
-                    f.write_str("\n            param_")?;
-                    f.write_str(&field.name.to_snek_case())?;
-                    f.write_str(": None,")?;
-                }
-
-                Ok(())
-            })?;
+                    Ok(())
+                })?;
 
             if has_fields || builder.body_required {
                 f.write_str("\n        }")?;

--- a/src/v2/codegen/object.rs
+++ b/src/v2/codegen/object.rs
@@ -835,7 +835,7 @@ impl<'a> Display for ApiObjectBuilder<'a> {
         }
 
         // Write struct fields and the associated markers if needed.
-        self.struct_fields_iter().try_for_each(|field| {
+        self.struct_fields_iter().try_for_each::<_, fmt::Result>(|field| {
             let (cc, sk) = (field.name.to_camel_case(), field.name.to_snek_case());
             if needs_container {
                 self.write_parameter_if_required(
@@ -897,7 +897,7 @@ impl Display for ApiObject {
 
         f.write_str(" {")?;
 
-        self.fields().iter().try_for_each(|field| {
+        self.fields().iter().try_for_each::<_, fmt::Result>(|field| {
             let mut new_name = field.name.to_snek_case();
             // Check if the field matches a Rust keyword and add '_' suffix.
             if RUST_KEYWORDS.iter().any(|&k| k == new_name) {


### PR DESCRIPTION
Without these changes, `paperclip` won't compile if any crate in the dep tree uses that feature. I made sure that the `kv_unstable` dependency is not part of `paperclip`, but only of the `dev-dependencies`, so we'll see the failure with `cargo test`, but not expose the feature to users of `paperclip`.