### PR TITLE
Forward user docs

### DIFF
--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -194,6 +194,9 @@ pub trait Apiv2Schema {
     /// Name of this schema. This is the object's name.
     const NAME: Option<&'static str> = None;
 
+    /// Description of this schema. In case the trait is derived, uses the documentation on the type.
+    const DESCRIPTION: &'static str = "";
+
     /// Returns the raw schema for this object.
     fn raw_schema() -> DefaultSchemaRaw {
         Default::default()
@@ -216,6 +219,9 @@ pub trait Apiv2Schema {
         let mut def = Self::raw_schema();
         if let Some(n) = Self::NAME {
             def.reference = Some(String::from("#/definitions/") + n);
+        }
+        if !Self::DESCRIPTION.is_empty() {
+            def.description = Some(Self::DESCRIPTION.to_owned());
         }
 
         def

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -391,9 +391,15 @@ fn handle_field_struct(
 
         let (ty_ref, is_required) = get_field_type(&field);
 
+        let docs = extract_documentation(&field.attrs);
+        let docs = docs.trim();
+
         let mut gen = quote!(
             {
-                let s = #ty_ref::raw_schema();
+                let mut s = #ty_ref::raw_schema();
+                if !#docs.is_empty() {
+                    s.description = Some(#docs.to_string());
+                }
                 schema.properties.insert(#field_name.into(), s.into());
             }
         );

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -42,12 +42,12 @@ pub fn api_v2_operation(_attr: TokenStream, input: TokenStream) -> TokenStream {
     self::actix::emit_v2_operation(input)
 }
 
-/// Marker attribute for indicating that an object is an OpenAPI v2 compatible definition.
+/// Derive attribute for indicating that a type is an OpenAPI v2 compatible definition.
 #[cfg(feature = "actix")]
 #[proc_macro_error]
-#[proc_macro_attribute]
-pub fn api_v2_schema(attrs: TokenStream, input: TokenStream) -> TokenStream {
-    self::actix::emit_v2_definition(attrs, input)
+#[proc_macro_derive(Apiv2Schema, attributes(openapi))]
+pub fn api_v2_schema(input: TokenStream) -> TokenStream {
+    self::actix::emit_v2_definition(input)
 }
 
 /// Marker attribute for indicating that the marked object can represent non-2xx (error)

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod web;
 
 pub use self::web::{Resource, Route, Scope};
-pub use paperclip_macros::{api_v2_errors, api_v2_operation, api_v2_schema};
+pub use paperclip_macros::{api_v2_errors, api_v2_operation, Apiv2Schema};
 
 use self::web::{RouteWrapper, ServiceConfig};
 use actix_service::ServiceFactory;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -14,11 +14,11 @@ use std::io::Cursor;
 use std::path::PathBuf;
 
 fn parse_version(s: &str) -> Result<OApiVersion, Error> {
-    Ok(match s {
-        "v2" => OApiVersion::V2,
-        "v3" => OApiVersion::V3,
-        _ => Err(PaperClipError::UnsupportedOpenAPIVersion)?,
-    })
+    match s {
+        "v2" => Ok(OApiVersion::V2),
+        "v3" => Ok(OApiVersion::V3),
+        _ => Err(PaperClipError::UnsupportedOpenAPIVersion.into()),
+    }
 }
 
 fn parse_spec(s: &str) -> Result<ResolvableApi<DefaultSchema>, Error> {
@@ -66,7 +66,7 @@ struct Opt {
 fn parse_args_and_run() -> Result<(), Error> {
     let opt = Opt::from_args();
     if let OApiVersion::V3 = opt.api {
-        Err(PaperClipError::UnsupportedOpenAPIVersion)?;
+        return Err(PaperClipError::UnsupportedOpenAPIVersion.into());
     }
 
     let spec = opt.spec.resolve()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use paperclip_macros::api_v2_schema_struct as api_v2_schema;
 pub mod actix {
     //! Plugin types, traits and macros for actix-web framework.
 
-    pub use paperclip_actix::{api_v2_errors, api_v2_operation, api_v2_schema};
+    pub use paperclip_actix::{api_v2_errors, api_v2_operation, Apiv2Schema};
     pub use paperclip_actix::{web, App, Mountable, OpenApiExt};
     pub use paperclip_core::v2::{OperationModifier, ResponderWrapper};
 }

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -36,6 +36,7 @@ enum PetClass {
 #[serde(rename_all = "camelCase")]
 /// Pets are awesome!
 struct Pet {
+    /// Pick a good one.
     name: String,
     class: PetClass,
     id: Option<u64>,
@@ -121,6 +122,7 @@ fn test_simple_app() {
                           "type": "integer"
                         },
                         "name": {
+                          "description": "Pick a good one.",
                           "type": "string"
                         },
                         "updatedOn": {
@@ -293,6 +295,7 @@ fn test_params() {
 
     #[derive(Deserialize, Apiv2Schema)]
     struct BadgeBody {
+        /// all your json are belong to us
         json: Option<serde_json::Value>,
         yaml: Option<serde_yaml::Value>,
     }
@@ -376,7 +379,7 @@ fn test_params() {
                   "definitions": {
                     "BadgeBody":{
                       "properties":{
-                        "json":{},
+                        "json":{"description": "all your json are belong to us"},
                         "yaml":{}
                       }
                     }
@@ -613,6 +616,7 @@ fn test_list_in_out() {
                           "type": "integer"
                         },
                         "name": {
+                          "description": "Pick a good one.",
                           "type": "string"
                         },
                         "updatedOn": {
@@ -746,6 +750,7 @@ fn test_impl_traits() {
                           "type": "integer"
                         },
                         "name": {
+                          "description": "Pick a good one.",
                           "type": "string"
                         },
                         "updatedOn": {
@@ -1034,6 +1039,7 @@ fn test_errors_app() {
                           "type": "integer"
                         },
                         "name": {
+                          "description": "Pick a good one.",
                           "type": "string"
                         },
                         "updatedOn": {

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -11,7 +11,7 @@ use actix_web::dev::{MessageBody, Payload, ServiceRequest, ServiceResponse};
 use actix_web::{App, Error, FromRequest, HttpRequest, HttpServer, Responder};
 use chrono;
 use futures::future::{ok as fut_ok, ready, Future, Ready};
-use paperclip::actix::{api_v2_errors, api_v2_operation, api_v2_schema, web, OpenApiExt};
+use paperclip::actix::{api_v2_errors, api_v2_operation, web, Apiv2Schema, OpenApiExt};
 use parking_lot::Mutex;
 
 use std::collections::{BTreeMap, HashSet};
@@ -23,8 +23,7 @@ lazy_static! {
     static ref PORTS: Mutex<HashSet<u16>> = Mutex::new(HashSet::new());
 }
 
-#[api_v2_schema]
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Apiv2Schema)]
 #[serde(rename_all = "lowercase")]
 enum PetClass {
     Dog,
@@ -33,8 +32,7 @@ enum PetClass {
     EverythingElse,
 }
 
-#[api_v2_schema]
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Apiv2Schema)]
 #[serde(rename_all = "camelCase")]
 struct Pet {
     name: String,
@@ -280,29 +278,25 @@ fn test_simple_app() {
 #[test]
 #[allow(dead_code)]
 fn test_params() {
-    #[api_v2_schema]
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Apiv2Schema)]
     struct KnownResourceBadge {
         resource: String,
         name: String,
     }
 
-    #[api_v2_schema]
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Apiv2Schema)]
     struct BadgeParams {
         res: Option<u16>,
         color: String,
     }
 
-    #[api_v2_schema]
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Apiv2Schema)]
     struct BadgeBody {
         json: Option<serde_json::Value>,
         yaml: Option<serde_yaml::Value>,
     }
 
-    #[api_v2_schema]
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Apiv2Schema)]
     struct BadgeForm {
         data: String,
     }
@@ -496,12 +490,10 @@ fn test_params() {
 
 #[test]
 fn test_map_in_out() {
-    #[api_v2_schema]
-    #[derive(Deserialize, Serialize)]
+    #[derive(Deserialize, Serialize, Apiv2Schema)]
     struct ImageId(u64);
 
-    #[api_v2_schema]
-    #[derive(Serialize)]
+    #[derive(Serialize, Apiv2Schema)]
     struct Image {
         data: String,
         id: ImageId,
@@ -571,15 +563,13 @@ fn test_map_in_out() {
 
 #[test]
 fn test_list_in_out() {
-    #[api_v2_schema]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Apiv2Schema)]
     enum Sort {
         Asc,
         Desc,
     }
 
-    #[api_v2_schema]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Apiv2Schema)]
     struct Params {
         sort: Option<Sort>,
         limit: Option<u16>,
@@ -678,8 +668,7 @@ fn test_impl_traits() {
         ""
     }
 
-    #[api_v2_schema]
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Apiv2Schema)]
     struct Params {
         limit: Option<u16>,
     }
@@ -911,7 +900,8 @@ fn test_multiple_method_routes() {
 
 #[test]
 fn test_custom_extractor_empty_schema() {
-    #[api_v2_schema(empty)]
+    #[derive(Apiv2Schema)]
+    #[openapi(empty)]
     struct SomeUselessThing<T>(T);
 
     impl FromRequest for SomeUselessThing<String> {

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -34,6 +34,7 @@ enum PetClass {
 
 #[derive(Deserialize, Serialize, Apiv2Schema)]
 #[serde(rename_all = "camelCase")]
+/// Pets are awesome!
 struct Pet {
     name: String,
     class: PetClass,
@@ -601,6 +602,7 @@ fn test_list_in_out() {
                   "info":{"title":"","version":""},
                   "definitions": {
                     "Pet": {
+                      "description": "Pets are awesome!",
                       "properties": {
                         "class": {
                           "enum": ["dog", "cat", "other"],
@@ -733,6 +735,7 @@ fn test_impl_traits() {
                   "info":{"title":"","version":""},
                   "definitions": {
                     "Pet": {
+                      "description": "Pets are awesome!",
                       "properties": {
                         "class": {
                           "enum": ["dog", "cat", "other"],


### PR DESCRIPTION
Based on #169

Causes any documentation on `#[derive(Apiv2Schema)]` types to get exposed as an OpenApi `description` field.