### PR TITLE
Migrate from failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ required-features = ["cli"]
 
 [dependencies]
 env_logger = { version = "0.7", optional = true }
-failure = "0.1"
-failure_derive = "0.1"
 git2 = { version = "0.13", optional = true }
 heck = { version = "0.3", optional = true }
 http = { version = "0.2", optional = true }
@@ -42,6 +40,8 @@ serde_yaml = "0.8"
 structopt = { version = "0.2", optional = true }
 tinytemplate = { version = "1.0", optional = true }
 url = "1.7"
+thiserror = "1.0.19"
+anyhow = "1.0.31"
 
 [dev-dependencies]
 actix-rt = "1.0"

--- a/book/build-script.md
+++ b/book/build-script.md
@@ -16,7 +16,7 @@ build = "build.rs"
 
 [dependencies]
 # Crates required by the generated code!
-failure = "0.1"
+thiserror = "1.0.19"
 futures = "0.1"
 parking_lot = "0.8"
 reqwest = "0.9"
@@ -63,10 +63,9 @@ fn main() {
 - Now, you can modify `src/main.rs` to make use of the generated code:
 
 ```rust
-#[macro_use] extern crate failure;
 #[macro_use] extern crate serde;
 
-use failure::Error;
+use thiserror::Error;
 use futures_preview::compat::Future01CompatExt;
 use reqwest::r#async::Client;
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ actix-web = { version = "2.0", optional = true }
 actix-http = { version = "1.0", optional = true }
 actix-multipart = { version = "0", optional = true }
 chrono = { version = "0", optional = true }
-failure = "0.1"
 heck = { version = "0.3", optional = true }
 lazy_static = "1.3"
 log = { version = "0.4", optional = true }
@@ -27,6 +26,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 uuid = { version = "0", optional = true }
+thiserror = "1.0.19"
 
 [features]
 actix = ["v2", "actix-http", "actix-web"]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,40 +1,38 @@
 #[cfg(feature = "v2")]
 use crate::v2::models::{DataType, ParameterIn};
-use failure::Fail;
+use thiserror::Error;
 
 /// Errors related to spec validation.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ValidationError {
     /// Failed to resolve the schema because an invalid URI was provided for
     /// `$ref` field.
     ///
     /// Currently, we only support `#/{definitions,parameters}/Name` in `$ref` field.
-    #[fail(
-        display = "Invalid $ref URI {:?}. Only relative URIs are supported.",
-        _0
-    )]
+    #[error("Invalid $ref URI {:?}. Only relative URIs are supported.", _0)]
     InvalidRefURI(String),
     /// The specified reference is missing in the spec.
-    #[fail(display = "Reference missing in spec: {}", _0)]
+    #[error("Reference missing in spec: {}", _0)]
     MissingReference(String),
     /// If a parameter specifies body, then schema must be specified.
-    #[fail(
-        display = "Parameter {:?} in path {:?} is a body but the schema is missing",
-        _0, _1
+    #[error(
+        "Parameter {:?} in path {:?} is a body but the schema is missing",
+        _0,
+        _1
     )]
     MissingSchemaForBodyParameter(String, String),
     /// Some headers have special meaning in OpenAPI. The user cannot have these headers
     /// in their API spec.
-    #[fail(
-        display = "Path {:?} has header parameter {:?} which is not allowed",
-        _1, _0
-    )]
+    #[error("Path {:?} has header parameter {:?} which is not allowed", _1, _0)]
     InvalidHeader(String, String),
     #[cfg(feature = "v2")]
     /// Only arrays and primitive types are allowed in parameters.
-    #[fail(
-        display = "Parameter {:?} in path {:?} has specified {:?} type, but it's invalid for {:?} parameters",
-        _0, _1, _2, _3
+    #[error(
+        "Parameter {:?} in path {:?} has specified {:?} type, but it's invalid for {:?} parameters",
+        _0,
+        _1,
+        _2,
+        _3
     )]
     InvalidParameterType(String, String, Option<DataType>, ParameterIn),
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Error;
 use paperclip::v2::{
     self,
     codegen::{CrateMeta, DefaultEmitter, EmitMode, Emitter, EmitterState},

--- a/src/build/cli_main.hbs
+++ b/src/build/cli_main.hbs
@@ -1,8 +1,8 @@
 
 use self::client::\{ApiClient, ApiError, Response};
 use self::util::ResponseStream;
+use anyhow::Error;
 use clap::\{App, ArgMatches};
-use failure::Error;
 use openssl::pkcs12::Pkcs12;
 use openssl::pkey::PKey;
 use openssl::x509::X509;
@@ -11,22 +11,22 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 #[allow(dead_code)]
 enum ClientError \{
-    #[fail(display = "Duration parse error: \{}", _0)]
+    #[error("Duration parse error: \{}", _0)]
     Duration(humantime::DurationError),
-    #[fail(display = "I/O error: \{}", _0)]
+    #[error("I/O error: \{}", _0)]
     Io(std::io::Error),
-    #[fail(display = "OpenSSL error: \{}", _0)]
+    #[error("OpenSSL error: \{}", _0)]
     OpenSsl(openssl::error::ErrorStack),
-    #[fail(display = "Client error: \{}", _0)]
+    #[error("Client error: \{}", _0)]
     Reqwest(reqwest::Error),
-    #[fail(display = "URL error: \{}", _0)]
+    #[error("URL error: \{}", _0)]
     Url(url::ParseError),
-    #[fail(display = "\{}", _0)]
+    #[error("\{}", _0)]
     Api(self::client::ApiError<reqwest::Response>),
-    #[fail(display = "")]
+    #[error("")]
     Empty,
 }
 

--- a/src/build/client_mod.hbs
+++ b/src/build/client_mod.hbs
@@ -1,6 +1,5 @@
 
 pub mod client \{
-    use failure::Fail;
     use futures::Stream;
     use parking_lot::Mutex;
 
@@ -9,18 +8,18 @@ pub mod client \{
     use std::path::Path;
 
     /// Common API errors.
-    #[derive(Debug, Fail)]
+    #[derive(Debug, thiserror::Error)]
     pub enum ApiError<R: Debug + Send + 'static> \{
-        #[fail(display = "API request failed for path: \{} (code: \{})", _0, _1)]
+        #[error("API request failed for path: \{} (code: \{})", _0, _1)]
         Failure(String, http::status::StatusCode, Mutex<R>),
-        #[fail(display = "Unsupported media type in response: \{}", _0)]
+        #[error("Unsupported media type in response: \{}", _0)]
         UnsupportedMediaType(String, Mutex<R>),
-        #[fail(display = "An error has occurred while performing the API request: \{}", _0)]
+        #[error("An error has occurred while performing the API request: \{}", _0)]
         Reqwest(reqwest::Error),
-        #[fail(display = "I/O error: \{}", _0)]
+        #[error("I/O error: \{}", _0)]
         Io(std::io::Error),
         {{- for coder in media_coders }}
-        #[fail(display = "Error en/decoding \"{coder.range | unescaped}\" data: \{}", _0)]
+        #[error("Error en/decoding \"{coder.range | unescaped}\" data: \{}", _0)]
         {coder.error_variant | unescaped}({coder.error_ty_path | unescaped}),
         {{- endfor }}
     }

--- a/src/build/manifest.hbs
+++ b/src/build/manifest.hbs
@@ -14,7 +14,7 @@ path = "lib.rs"
 [dependencies]
 async-trait = "0.1"
 bytes = "0.5"
-failure = "0.1"
+thiserror = "1.0.19"
 futures = "0.3"
 http = "0.2"
 lazy_static = "1.4"
@@ -28,6 +28,7 @@ serde_yaml = "0.8"
 tokio-util = \{ version = "0.3", features = ["codec"] }
 url = "2.1"
 {{ if is_cli }}
+anyhow = "1.0"
 clap = \{ version = "2.33", features = ["yaml"] }
 env_logger = "0.6"
 humantime = "1.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,56 +15,53 @@ macro_rules! impl_err_from {
 pub type PaperClipResult<T> = Result<T, PaperClipError>;
 
 /// Global error which encapsulates all related errors.
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum PaperClipError {
     /// Error encountered during spec validation.
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     Validation(paperclip_core::ValidationError),
     /// The given directory cannot be used for generating code.
-    #[fail(display = "Cannot generate code in the given directory")]
+    #[error("Cannot generate code in the given directory")]
     InvalidCodegenDirectory,
     /// Currently, we only support OpenAPI v2, and eventually v3.
-    #[fail(display = "This version of OpenAPI is unsupported.")]
+    #[error("This version of OpenAPI is unsupported.")]
     UnsupportedOpenAPIVersion,
     /// Paths listed in the spec must be unique.
-    #[fail(display = "Path similar to {:?} already exists.", _0)]
+    #[error("Path similar to {:?} already exists.", _0)]
     RelativePathNotUnique(String),
-    #[fail(
-        display = "Parameter(s) {:?} aren't defined for templated path {:?}",
-        _1, _0
-    )]
+    #[error("Parameter(s) {:?} aren't defined for templated path {:?}", _1, _0)]
     MissingParametersInPath(String, HashSet<String>),
     /// Invalid host for URL.
-    #[fail(display = "Cannot parse host {:?}: {}", _0, _1)]
+    #[error("Cannot parse host {:?}: {}", _0, _1)]
     InvalidHost(String, url::ParseError),
     /// Invalid base path URL.
-    #[fail(display = "Cannot set URL {:?}: {}", _0, _1)]
+    #[error("Cannot set URL {:?}: {}", _0, _1)]
     InvalidBasePathURL(String, url::ParseError),
     /// The given schema object is an array, but the `items` field is missing.
-    #[fail(display = "Mising item schema for array: {:?}", _0)]
+    #[error("Mising item schema for array: {:?}", _0)]
     MissingArrayItem(Option<String>),
     /// The name for the given definition is missing or invalid.
-    #[fail(display = "Invalid name for definition")]
+    #[error("Invalid name for definition")]
     InvalidDefinitionName,
     /// A valid path cannot be obtained for the given definition.
-    #[fail(display = "Invalid path for definition: {:?}", _0)]
+    #[error("Invalid path for definition: {:?}", _0)]
     InvalidDefinitionPath(PathBuf),
     /// I/O errors.
-    #[fail(display = "I/O error: {}", _0)]
+    #[error("I/O error: {}", _0)]
     Io(std::io::Error),
     /// JSON coding errors.
-    #[fail(display = "JSON error: {}", _0)]
+    #[error("JSON error: {}", _0)]
     Json(serde_json::Error),
     /// YAML coding errors.
-    #[fail(display = "YAML error: {}", _0)]
+    #[error("YAML error: {}", _0)]
     Yaml(serde_yaml::Error),
     #[cfg(feature = "codegen-fmt")]
     /// Errors from rustfmt.
-    #[fail(display = "Rustfmt formatting error: {}", _0)]
+    #[error("Rustfmt formatting error: {}", _0)]
     RustFmt(rustfmt_nightly::ErrorKind),
     #[cfg(feature = "codegen")]
     /// Errors in templating.
-    #[fail(display = "Templating error: {}", _0)]
+    #[error("Templating error: {}", _0)]
     Templating(tinytemplate::error::Error),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 //! See the [website](https://paperclip.waffles.space) for detailed
 //! documentation and examples.
 
-#[macro_use]
-extern crate failure;
 #[cfg_attr(feature = "codegen", macro_use)]
 #[cfg(feature = "codegen")]
 extern crate log;

--- a/src/v2/codegen/author.rs
+++ b/src/v2/codegen/author.rs
@@ -2,7 +2,7 @@
 //!
 //! Obtained from [Cargo](https://github.com/rust-lang/cargo/blob/fa05862cd0c6b899b801fda0f256ac5b9bae69d9/src/cargo/ops/cargo_new.rs#L690-L750).
 
-use failure::Error;
+use anyhow::Error;
 use git2::Config as GitConfig;
 use git2::Repository as GitRepository;
 
@@ -39,7 +39,7 @@ pub(super) fn discover() -> Result<(String, Option<String>), Error> {
         Some(name) => name,
         None => {
             let username_var = if cfg!(windows) { "USERNAME" } else { "USER" };
-            failure::bail!(
+            anyhow::bail!(
                 "could not determine the current user, please set ${}",
                 username_var
             )

--- a/src/v2/codegen/emitter.rs
+++ b/src/v2/codegen/emitter.rs
@@ -13,7 +13,7 @@ use crate::v2::{
     },
     Schema,
 };
-use failure::Error;
+use anyhow::Error;
 use heck::{CamelCase, SnekCase};
 use http::{header::HeaderName, HeaderMap};
 use itertools::Itertools;

--- a/src/v2/codegen/state.rs
+++ b/src/v2/codegen/state.rs
@@ -2,7 +2,7 @@ use super::template::{self, TEMPLATE};
 use super::{object::ApiObject, CrateMeta, EmitMode};
 use crate::error::PaperClipError;
 use crate::v2::models::{Coders, SpecFormat};
-use failure::Error;
+use anyhow::Error;
 use heck::CamelCase;
 #[cfg(feature = "cli")]
 use heck::SnekCase;
@@ -127,8 +127,6 @@ impl EmitterState {
                 mod_path = self.root_module_path();
                 contents.push_str(
                     "
-#[macro_use]
-extern crate failure;
 #[macro_use]
 extern crate serde;
 ",

--- a/tests/test_codegen.rs
+++ b/tests/test_codegen.rs
@@ -68,8 +68,6 @@ fn test_lib_creation() {
         &(ROOT.clone() + "/tests/test_pet/lib.rs"),
         "
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate serde;
 
 pub mod category {
@@ -142,7 +140,7 @@ path = \"lib.rs\"
 [dependencies]
 async-trait = \"0.1\"
 bytes = \"0.5\"
-failure = \"0.1\"
+thiserror = \"1.0.19\"
 futures = \"0.3\"
 http = \"0.2\"
 lazy_static = \"1.4\"
@@ -189,7 +187,7 @@ fn test_overridden_path() {
         }
     }
 ",
-        Some(7433),
+        Some(7333),
     );
 }
 

--- a/tests/test_k8s.rs
+++ b/tests/test_k8s.rs
@@ -776,7 +776,6 @@ pub mod miscellaneous {
 }
 
 pub mod client {
-    use failure::Fail;
     use futures::Stream;
     use parking_lot::Mutex;
 
@@ -785,19 +784,19 @@ pub mod client {
     use std::path::Path;
 
     /// Common API errors.
-    #[derive(Debug, Fail)]
+    #[derive(Debug, thiserror::Error)]
     pub enum ApiError<R: Debug + Send + 'static> {
-        #[fail(display = \"API request failed for path: {} (code: {})\", _0, _1)]
+        #[error(\"API request failed for path: {} (code: {})\", _0, _1)]
         Failure(String, http::status::StatusCode, Mutex<R>),
-        #[fail(display = \"Unsupported media type in response: {}\", _0)]
+        #[error(\"Unsupported media type in response: {}\", _0)]
         UnsupportedMediaType(String, Mutex<R>),
-        #[fail(display = \"An error has occurred while performing the API request: {}\", _0)]
+        #[error(\"An error has occurred while performing the API request: {}\", _0)]
         Reqwest(reqwest::Error),
-        #[fail(display = \"I/O error: {}\", _0)]
+        #[error(\"I/O error: {}\", _0)]
         Io(std::io::Error),
-        #[fail(display = \"Error en/decoding \\\"application/json\\\" data: {}\", _0)]
+        #[error(\"Error en/decoding \\\"application/json\\\" data: {}\", _0)]
         ApplicationJson(serde_json::Error),
-        #[fail(display = \"Error en/decoding \\\"application/yaml\\\" data: {}\", _0)]
+        #[error(\"Error en/decoding \\\"application/yaml\\\" data: {}\", _0)]
         ApplicationYaml(serde_yaml::Error),
     }
 
@@ -1656,7 +1655,7 @@ path = \"main.rs\"
 [dependencies]
 async-trait = \"0.1\"
 bytes = \"0.5\"
-failure = \"0.1\"
+thiserror = \"1.0.19\"
 futures = \"0.3\"
 http = \"0.2\"
 lazy_static = \"1.4\"
@@ -1670,6 +1669,7 @@ serde_yaml = \"0.8\"
 tokio-util = { version = \"0.3\", features = [\"codec\"] }
 url = \"2.1\"
 
+anyhow = \"1.0\"
 clap = { version = \"2.33\", features = [\"yaml\"] }
 env_logger = \"0.6\"
 humantime = \"1.2\"
@@ -1692,8 +1692,8 @@ fn test_cli_main() {
         "
 use self::client::{ApiClient, ApiError, Response};
 use self::util::ResponseStream;
+use anyhow::Error;
 use clap::{App, ArgMatches};
-use failure::Error;
 use openssl::pkcs12::Pkcs12;
 use openssl::pkey::PKey;
 use openssl::x509::X509;
@@ -1702,22 +1702,22 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 #[allow(dead_code)]
 enum ClientError {
-    #[fail(display = \"Duration parse error: {}\", _0)]
+    #[error(\"Duration parse error: {}\", _0)]
     Duration(humantime::DurationError),
-    #[fail(display = \"I/O error: {}\", _0)]
+    #[error(\"I/O error: {}\", _0)]
     Io(std::io::Error),
-    #[fail(display = \"OpenSSL error: {}\", _0)]
+    #[error(\"OpenSSL error: {}\", _0)]
     OpenSsl(openssl::error::ErrorStack),
-    #[fail(display = \"Client error: {}\", _0)]
+    #[error(\"Client error: {}\", _0)]
     Reqwest(reqwest::Error),
-    #[fail(display = \"URL error: {}\", _0)]
+    #[error(\"URL error: {}\", _0)]
     Url(url::ParseError),
-    #[fail(display = \"{}\", _0)]
+    #[error(\"{}\", _0)]
     Api(self::client::ApiError<reqwest::Response>),
-    #[fail(display = \"\")]
+    #[error(\"\")]
     Empty,
 }
 
@@ -1841,7 +1841,7 @@ async fn main() {
     }
 }
 ",
-        Some(12935),
+        Some(12835),
     );
 }
 

--- a/tests/test_k8s/Cargo.toml
+++ b/tests/test_k8s/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 [dependencies]
 async-trait = "0.1"
 bytes = "0.5"
-failure = "0.1"
+thiserror = "1.0.19"
 futures = "0.3"
 http = "0.2"
 lazy_static = "1.4"

--- a/tests/test_k8s/lib.rs
+++ b/tests/test_k8s/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use] extern crate failure;
 #[macro_use] extern crate serde;
 
 mod codegen {


### PR DESCRIPTION
`failure` is deprecated, and `thiserror` + `anyhow` combination is the most similar migration target.