### PR TITLE
Reorder CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,10 @@ cache: cargo
 node_js: "12"
 install: "npm install -g gitbook-cli"
 
+
+# jobs are sorted by duration to optimize time to completion
 matrix:
   include:
-  - name: check
-    before_script:
-    - rustup component add rustfmt clippy
-    script:
-    - cargo fmt --all -- --check
-    - cargo clippy --all -- -D clippy::all
-  - name: build
-    script:
-    - cargo build
-    - cargo build --features actix
-    - cargo build --features cli
-  - name: test-nightly
-    before_script:
-    - rustup toolchain install nightly
-    - rustup default nightly
-    script:
-    - cargo test --all --features "actix-nightly cli chrono uuid"
   - name: test
     script:
     - cargo test --all --features "actix cli chrono uuid"
@@ -30,12 +15,29 @@ matrix:
     - cd ../test_pet && cargo check
     - cd cli && CARGO_TARGET_DIR=../target cargo check
     - cd ../../test_k8s/cli && CARGO_TARGET_DIR=../target cargo check
+  - name: test-nightly
+    before_script:
+    - rustup toolchain install nightly
+    - rustup default nightly
+    script:
+    - cargo test --all --features "actix-nightly cli chrono uuid"
+  - name: build
+    script:
+    - cargo build
+    - cargo build --features actix
+    - cargo build --features cli
   - name: docs
     script:
     - rm -rf target/doc
     - cargo doc --all --features "actix cli chrono uuid" --no-deps
     - gitbook build book/
     - cp -r book/_book/* target/doc/
+  - name: check
+    before_script:
+    - rustup component add rustfmt clippy
+    script:
+    - cargo fmt --all -- --check
+    - cargo clippy --all -- -D clippy::all
 
 deploy:
   provider: pages


### PR DESCRIPTION
I sorted them by duration. 
Because Travis launches them sequentially in declaration order, this will optimize total wait time when not all workers are available.