### PR TITLE
Fix a mis-namespaced TokenStream ref

### DIFF
--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -397,7 +397,7 @@ pub fn emit_v2_security(input: TokenStream) -> TokenStream {
         }
     }
 
-    fn quote_option(value: Option<&String>) -> proc_macro_error::proc_macro2::TokenStream {
+    fn quote_option(value: Option<&String>) -> proc_macro2::TokenStream {
         if let Some(value) = value {
             quote! { Some(#value.to_string()) }
         } else {


### PR DESCRIPTION
This should fix the broken build.

I was trying to figure out how this ever worked, and why it suddenly broke. Looks like `proc-macro-error` introduced a "breaking" (IMO this never should have worked) change from 1.0.2 to 1.0.3, as everything is green if you pin `proc-macro-error` to `=1.0.2`. I'm an absolute novice here, but [this jumped out](https://gitlab.com/CreepySkeleton/proc-macro-error/-/commit/141ebd775d63ada98d9f17eca8762d6c3522d55e).