### PR TITLE
Fix actix-web features documentation

### DIFF
--- a/book/actix-plugin.md
+++ b/book/actix-plugin.md
@@ -13,7 +13,7 @@ actix-web = "2.0"
 # this plugin works smoothly with the nightly compiler, it also works in stable
 # channel (remove "nightly" feature in that case). There maybe compilation errors,
 # but those can be fixed.
-paperclip = { version = "0.4", features = ["actix", "nightly"] }
+paperclip = { version = "0.4", features = ["actix-nightly"] }
 serde = "1.0"
 ```
 


### PR DESCRIPTION
According to the book, `actix` and `nightly` features should be used, but as far as I can [see](https://github.com/wafflespeanut/paperclip/blob/master/Cargo.toml#L58), `actix-nightly` should be used instead.