### PR TITLE
Impl schema for serde values as "other"

### DIFF
--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -182,6 +182,8 @@ impl_type_simple!(isize, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(u64, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(u128, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(usize, DataType::Integer, DataTypeFormat::Int64);
+impl_type_simple!(serde_json::Value, DataType::Object);
+impl_type_simple!(serde_yaml::Value, DataType::Object);
 #[cfg(feature = "actix-multipart")]
 impl_type_simple!(
     actix_multipart::Multipart,
@@ -344,9 +346,6 @@ impl<'a, T: Apiv2Schema> Apiv2Schema for &'a [T] {
         Vec::<T>::raw_schema()
     }
 }
-
-impl Apiv2Schema for serde_json::Value {}
-impl Apiv2Schema for serde_yaml::Value {}
 
 macro_rules! impl_schema_array {
     ($ty:ty) => {

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -384,8 +384,8 @@ fn test_params() {
                   "definitions": {
                     "BadgeBody":{
                       "properties":{
-                        "json":{"description": "JSON value"},
-                        "yaml":{}
+                        "json": {"description": "JSON value", "type": "object"},
+                        "yaml": {"type": "object"}
                       }
                     }
                   },


### PR DESCRIPTION
Now, when serde_json::Value or serde_yaaml::Value is used in schema, it doesn't have type present in specs which makes it invisible in swagger web interface.
This PR makes it seen as "object", thus visible in swagger web interface as "{}".