### PR TITLE
refactor: Extended the support to wider range of versions of some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,18 @@ log = { version = "0.4", optional = true }
 paperclip-actix = { path = "plugins/actix-web", version = "0.2.1", optional = true }
 paperclip-core = { path = "core", version = "0.2.1" }
 paperclip-macros = { path = "macros", version = "0.3.1", optional = true }
-parking_lot = { version = "0.11" }
+parking_lot = { version = ">=0.10,<0.12" }
 regex = { version = "1.1", optional = true }
 reqwest = { version = "0.10", features = ["blocking"], optional = true }
 # rustfmt-nightly = { version = "1.2.2", optional = true }
-semver = "0.10"
+semver = ">=0.9,<0.11"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 structopt = { version = "0.2", optional = true }
 tinytemplate = { version = "1.0", optional = true }
-url = "1.7"
+url = ">=1.7,<3"
 thiserror = "1.0.19"
 anyhow = "1.0.31"
 once_cell = "1.4.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,7 @@ once_cell = "1.4.0"
 log = { version = "0.4", optional = true }
 mime = "0.3"
 paperclip-macros = { path = "../macros", version = "0.3.1" }
-parking_lot = { version = "0.11", features = ["serde"] }
+parking_lot = { version = ">=0.10,<0.12", features = ["serde"] }
 rust_decimal = { version = "1", optional = true }
 regex = "1.1"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/plugins/actix-web/Cargo.toml
+++ b/plugins/actix-web/Cargo.toml
@@ -15,7 +15,7 @@ actix-service = "1.0"
 actix-web = "2.0"
 paperclip-core = { path = "../../core", version = "0.2.1", features = ["actix"] }
 paperclip-macros = { path = "../../macros", version = "0.3.1", features = ["actix"] }
-parking_lot = "0.11"
+parking_lot = ">=0.10,<0.12"
 serde_json = "1.0"
 once_cell = "1.4.0"
 


### PR DESCRIPTION
This needs so Cargo can deduplicate some of the dependencies when used with other packages in the project.

Paperclip seems to be working just fine with these even though the versions have some breaking changes.