### PR TITLE
Add example field to schema and add description to operation parameter

### DIFF
--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -295,6 +295,7 @@ macro_rules! impl_param_extractor ({ $ty:ty => $container:ident } => {
                     data_type: v.data_type,
                     format: v.format,
                     enum_: v.enum_,
+                    description: v.description,
                     ..Default::default()
                 }));
             }

--- a/macros/src/core.rs
+++ b/macros/src/core.rs
@@ -285,6 +285,10 @@ fn schema_fields(name: &Ident, is_ref: bool) -> proc_macro2::TokenStream {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub format: Option<paperclip::v2::models::DataTypeFormat>,
     ));
+    gen.extend(quote!(
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub example: Option<String>,
+    ));
 
     gen.extend(quote!(
         #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]


### PR DESCRIPTION
This PR adds example field to schema, so custom Apiv2Schema implementations can specify example for properties.

Also operation parameter would inherit description from the schema type.