### PR TITLE
Fix shared parameters generation

### DIFF
--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -346,12 +346,21 @@ impl<S> PathItem<Parameter<S>, Response<S>> {
         // We're using `Option<BTreeSet>` over `BTreeSet` because we need to
         // differentiate between the first operation that we use for initial
         // value of the set and  an operation that doesn't have any parameters.
+        if self.methods.len() < 2 {
+            return;
+        }
         let mut shared_params = None;
         for op in self.methods.values() {
             let params = op
                 .parameters
                 .iter()
-                .map(|p| p.name.clone())
+                .filter_map(|p| {
+                    if p.name != "body" {
+                        Some(p.name.clone())
+                    } else {
+                        None
+                    }
+                })
                 .collect::<BTreeSet<_>>();
             if let Some(p) = shared_params.take() {
                 shared_params = Some(&p & &params); // set intersection

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -346,21 +346,22 @@ impl<S> PathItem<Parameter<S>, Response<S>> {
         // We're using `Option<BTreeSet>` over `BTreeSet` because we need to
         // differentiate between the first operation that we use for initial
         // value of the set and  an operation that doesn't have any parameters.
-        if self.methods.len() < 2 {
-            return;
-        }
+        // if self.methods.len() < 2 {
+        //     return;
+        // }
         let mut shared_params = None;
         for op in self.methods.values() {
             let params = op
                 .parameters
                 .iter()
-                .filter_map(|p| {
-                    if p.name != "body" {
-                        Some(p.name.clone())
-                    } else {
-                        None
-                    }
-                })
+                .map(|p| p.name.clone())
+                // .filter_map(|p| {
+                //     if p.name != "body" {
+                //         Some(p.name.clone())
+                //     } else {
+                //         None
+                //     }
+                // })
                 .collect::<BTreeSet<_>>();
             if let Some(p) = shared_params.take() {
                 shared_params = Some(&p & &params); // set intersection

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -346,22 +346,12 @@ impl<S> PathItem<Parameter<S>, Response<S>> {
         // We're using `Option<BTreeSet>` over `BTreeSet` because we need to
         // differentiate between the first operation that we use for initial
         // value of the set and  an operation that doesn't have any parameters.
-        // if self.methods.len() < 2 {
-        //     return;
-        // }
         let mut shared_params = None;
         for op in self.methods.values() {
             let params = op
                 .parameters
                 .iter()
                 .map(|p| p.name.clone())
-                // .filter_map(|p| {
-                //     if p.name != "body" {
-                //         Some(p.name.clone())
-                //     } else {
-                //         None
-                //     }
-                // })
                 .collect::<BTreeSet<_>>();
             if let Some(p) = shared_params.take() {
                 shared_params = Some(&p & &params); // set intersection

--- a/plugins/actix-web/Cargo.toml
+++ b/plugins/actix-web/Cargo.toml
@@ -21,3 +21,4 @@ once_cell = "1.4.0"
 
 [features]
 nightly = ["paperclip-core/actix", "paperclip-core/nightly"]
+normalize = []

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -279,8 +279,10 @@ where
             &mut api.security_definitions,
         );
         factory.update_operations(&mut api.paths);
-        for map in api.paths.values_mut() {
-            map.normalize();
+        if cfg!(feature = "normalize") {
+            for map in api.paths.values_mut() {
+                map.normalize();
+            }
         }
     }
 }

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -151,15 +151,15 @@ fn test_simple_app() {
                   },
                   "paths": {
                     "/api/echo": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -171,15 +171,15 @@ fn test_simple_app() {
                       }
                     },
                     "/api/async_echo": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -191,15 +191,15 @@ fn test_simple_app() {
                       }
                     },
                     "/api/async_echo_2": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -355,6 +355,14 @@ fn test_params() {
         ready("")
     }
 
+    #[api_v2_operation]
+    fn patch_badge_2(
+        _p: web::Path<(u32, String)>,
+        _b: web::Json<BadgeBody>,
+    ) -> impl Future<Output = &'static str> {
+        ready("")
+    }
+
     run_and_check_app(
         || {
             App::new()
@@ -373,7 +381,8 @@ fn test_params() {
                                 .service(
                                     web::resource("/v/{name}")
                                         .route(web::get().to(get_known_badge_2))
-                                        .route(web::post().to(post_badge_2)),
+                                        .route(web::post().to(post_badge_2))
+                                        .route(web::patch().to(patch_badge_2)),
                                 )
                                 .service(
                                     web::resource("/foo").route(web::get().to(get_resource_2)),
@@ -453,15 +462,15 @@ fn test_params() {
                     },
                     "/api/v2/{resource}/foo": {
                       "get": {
+                        "parameters": [{
+                            "format": "int32",
+                            "in": "path",
+                            "name": "resource",
+                            "required": true,
+                            "type": "integer"
+                          }],
                         "responses": {}
                       },
-                      "parameters": [{
-                        "format": "int32",
-                        "in": "path",
-                        "name": "resource",
-                        "required": true,
-                        "type": "integer"
-                      }]
                     },
                     "/api/v2/{resource}/v/{name}": {
                       "get": {
@@ -491,6 +500,17 @@ fn test_params() {
                         "type": "integer"
                       }],
                       "post": {
+                        "parameters": [{
+                          "in": "body",
+                          "name": "body",
+                          "required": true,
+                          "schema": {
+                            "$ref": "#/definitions/BadgeBody"
+                          }
+                        }],
+                        "responses": {}
+                      },
+                      "patch": {
                         "parameters": [{
                           "in": "body",
                           "name": "body",
@@ -652,6 +672,17 @@ fn test_list_in_out() {
                   "paths": {
                     "/pets": {
                       "get": {
+                        "parameters": [{
+                            "format": "int32",
+                            "in": "query",
+                            "name": "limit",
+                            "type": "integer"
+                          }, {
+                            "enum": ["Asc", "Desc"],
+                            "in": "query",
+                            "name": "sort",
+                            "type": "string"
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -664,17 +695,6 @@ fn test_list_in_out() {
                           }
                         }
                       },
-                      "parameters": [{
-                        "format": "int32",
-                        "in": "query",
-                        "name": "limit",
-                        "type": "integer"
-                      }, {
-                        "enum": ["Asc", "Desc"],
-                        "in": "query",
-                        "name": "sort",
-                        "type": "string"
-                      }],
                     }
                   },
                   "swagger": "2.0"
@@ -777,6 +797,12 @@ fn test_impl_traits() {
                     },
                     "/pets": {
                       "get": {
+                        "parameters": [{
+                            "format": "int32",
+                            "in": "query",
+                            "name": "limit",
+                            "type": "integer"
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -789,12 +815,6 @@ fn test_impl_traits() {
                           }
                         }
                       },
-                      "parameters": [{
-                        "format": "int32",
-                        "in": "query",
-                        "name": "limit",
-                        "type": "integer"
-                      }]
                     },
                     "/pet": {
                       "get": {
@@ -894,7 +914,16 @@ fn test_operation_with_generics() {
                      "paths":{
                         "/pet/id/{id}":{
                            "get":{
-                              "responses":{
+                            "parameters":[
+                                {
+                                   "format":"int64",
+                                   "in":"path",
+                                   "name":"id",
+                                   "required":true,
+                                   "type":"integer"
+                                }
+                            ],
+                            "responses":{
                                  "200":{
                                     "description":"OK",
                                     "schema":{
@@ -906,19 +935,18 @@ fn test_operation_with_generics() {
                                  }
                               }
                            },
-                           "parameters":[
-                              {
-                                 "format":"int64",
-                                 "in":"path",
-                                 "name":"id",
-                                 "required":true,
-                                 "type":"integer"
-                              }
-                           ]
                         },
                         "/pet/name/{name}":{
                            "get":{
-                              "responses":{
+                            "parameters":[
+                                {
+                                   "in":"path",
+                                   "name":"name",
+                                   "required":true,
+                                   "type":"string"
+                                }
+                            ],
+                            "responses":{
                                  "200":{
                                     "description":"OK",
                                     "schema":{
@@ -930,14 +958,6 @@ fn test_operation_with_generics() {
                                  }
                               }
                            },
-                           "parameters":[
-                              {
-                                 "in":"path",
-                                 "name":"name",
-                                 "required":true,
-                                 "type":"string"
-                              }
-                           ]
                         }
                      },
                      "swagger":"2.0"
@@ -1051,6 +1071,12 @@ fn test_operations_documentation() {
                     "/pets": {
                       "get": {
                         "description":"Will provide list of all pets available for sale",
+                        "parameters": [{
+                            "format": "int32",
+                            "in": "query",
+                            "name": "limit",
+                            "type": "integer"
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -1064,12 +1090,6 @@ fn test_operations_documentation() {
                         },
                         "summary":"List all pets"
                       },
-                      "parameters": [{
-                        "format": "int32",
-                        "in": "query",
-                        "name": "limit",
-                        "type": "integer"
-                      }]
                     },
                     "/pet": {
                       "get": {
@@ -1347,15 +1367,15 @@ fn test_errors_app() {
                   },
                   "paths": {
                     "/api/echo": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -1504,15 +1524,15 @@ fn test_security_app() {
                   },
                   "paths": {
                     "/api/echo1": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -1529,15 +1549,15 @@ fn test_security_app() {
                       }
                     },
                     "/api/echo2": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -151,15 +151,15 @@ fn test_simple_app() {
                   },
                   "paths": {
                     "/api/echo": {
+                      "parameters": [{
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Pet"
+                        }
+                      }],
                       "post": {
-                        "parameters": [{
-                            "in": "body",
-                            "name": "body",
-                            "required": true,
-                            "schema": {
-                              "$ref": "#/definitions/Pet"
-                            }
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -171,15 +171,15 @@ fn test_simple_app() {
                       }
                     },
                     "/api/async_echo": {
+                      "parameters": [{
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Pet"
+                        }
+                      }],
                       "post": {
-                        "parameters": [{
-                            "in": "body",
-                            "name": "body",
-                            "required": true,
-                            "schema": {
-                              "$ref": "#/definitions/Pet"
-                            }
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -191,15 +191,15 @@ fn test_simple_app() {
                       }
                     },
                     "/api/async_echo_2": {
+                      "parameters": [{
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Pet"
+                        }
+                      }],
                       "post": {
-                        "parameters": [{
-                            "in": "body",
-                            "name": "body",
-                            "required": true,
-                            "schema": {
-                              "$ref": "#/definitions/Pet"
-                            }
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -313,6 +313,12 @@ fn test_params() {
     }
 
     #[derive(Deserialize, Apiv2Schema)]
+    struct BadgeBodyPatch {
+        /// JSON value
+        json: Option<serde_json::Value>,
+    }
+
+    #[derive(Deserialize, Apiv2Schema)]
     struct BadgeForm {
         data: String,
     }
@@ -355,10 +361,19 @@ fn test_params() {
         ready("")
     }
 
+
     #[api_v2_operation]
-    fn patch_badge_2(
-        _p: web::Path<(u32, String)>,
+    fn post_badge_3(
+        _p: web::Path<u32>,
         _b: web::Json<BadgeBody>,
+    ) -> impl Future<Output = &'static str> {
+        ready("")
+    }
+
+    #[api_v2_operation]
+    fn patch_badge_3(
+        _p: web::Path<u32>,
+        _b: web::Json<BadgeBodyPatch>,
     ) -> impl Future<Output = &'static str> {
         ready("")
     }
@@ -382,7 +397,11 @@ fn test_params() {
                                     web::resource("/v/{name}")
                                         .route(web::get().to(get_known_badge_2))
                                         .route(web::post().to(post_badge_2))
-                                        .route(web::patch().to(patch_badge_2)),
+                                )
+                                .service(
+                                web::resource("/v")
+                                        .route(web::post().to(post_badge_3))
+                                        .route(web::patch().to(patch_badge_3)),
                                 )
                                 .service(
                                     web::resource("/foo").route(web::get().to(get_resource_2)),
@@ -407,6 +426,11 @@ fn test_params() {
                         "json": {"description": "JSON value", "type": "object"},
                         "yaml": {"type": "object"}
                       }
+                    },
+                    "BadgeBodyPatch":{
+                        "properties":{
+                          "json": {"description": "JSON value", "type": "object"},
+                        }
                     }
                   },
                   "paths": {
@@ -462,15 +486,15 @@ fn test_params() {
                     },
                     "/api/v2/{resource}/foo": {
                       "get": {
-                        "parameters": [{
-                            "format": "int32",
-                            "in": "path",
-                            "name": "resource",
-                            "required": true,
-                            "type": "integer"
-                          }],
                         "responses": {}
                       },
+                      "parameters": [{
+                        "format": "int32",
+                        "in": "path",
+                        "name": "resource",
+                        "required": true,
+                        "type": "integer"
+                      }]
                     },
                     "/api/v2/{resource}/v/{name}": {
                       "get": {
@@ -509,18 +533,38 @@ fn test_params() {
                           }
                         }],
                         "responses": {}
-                      },
-                      "patch": {
+                      }
+                    }
+                  },
+                  "/api/v2/{resource}/v": {
+                    "parameters": [{
+                      "format": "int32",
+                      "in": "path",
+                      "name": "resource",
+                      "required": true,
+                      "type": "integer"
+                    }],
+                    "post": {
+                      "parameters": [{
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/BadgeBody"
+                        }
+                      }],
+                      "responses": {}
+                    },
+                    "patch": {
                         "parameters": [{
                           "in": "body",
                           "name": "body",
                           "required": true,
                           "schema": {
-                            "$ref": "#/definitions/BadgeBody"
+                            "$ref": "#/definitions/BadgeBodyPatch"
                           }
                         }],
                         "responses": {}
-                      }
                     }
                   },
                   "swagger": "2.0"
@@ -672,17 +716,6 @@ fn test_list_in_out() {
                   "paths": {
                     "/pets": {
                       "get": {
-                        "parameters": [{
-                            "format": "int32",
-                            "in": "query",
-                            "name": "limit",
-                            "type": "integer"
-                          }, {
-                            "enum": ["Asc", "Desc"],
-                            "in": "query",
-                            "name": "sort",
-                            "type": "string"
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -695,6 +728,17 @@ fn test_list_in_out() {
                           }
                         }
                       },
+                      "parameters": [{
+                        "format": "int32",
+                        "in": "query",
+                        "name": "limit",
+                        "type": "integer"
+                      }, {
+                        "enum": ["Asc", "Desc"],
+                        "in": "query",
+                        "name": "sort",
+                        "type": "string"
+                      }],
                     }
                   },
                   "swagger": "2.0"
@@ -797,12 +841,6 @@ fn test_impl_traits() {
                     },
                     "/pets": {
                       "get": {
-                        "parameters": [{
-                            "format": "int32",
-                            "in": "query",
-                            "name": "limit",
-                            "type": "integer"
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -815,6 +853,12 @@ fn test_impl_traits() {
                           }
                         }
                       },
+                      "parameters": [{
+                        "format": "int32",
+                        "in": "query",
+                        "name": "limit",
+                        "type": "integer"
+                      }]
                     },
                     "/pet": {
                       "get": {
@@ -914,16 +958,7 @@ fn test_operation_with_generics() {
                      "paths":{
                         "/pet/id/{id}":{
                            "get":{
-                            "parameters":[
-                                {
-                                   "format":"int64",
-                                   "in":"path",
-                                   "name":"id",
-                                   "required":true,
-                                   "type":"integer"
-                                }
-                            ],
-                            "responses":{
+                              "responses":{
                                  "200":{
                                     "description":"OK",
                                     "schema":{
@@ -935,18 +970,19 @@ fn test_operation_with_generics() {
                                  }
                               }
                            },
+                           "parameters":[
+                              {
+                                 "format":"int64",
+                                 "in":"path",
+                                 "name":"id",
+                                 "required":true,
+                                 "type":"integer"
+                              }
+                           ]
                         },
                         "/pet/name/{name}":{
                            "get":{
-                            "parameters":[
-                                {
-                                   "in":"path",
-                                   "name":"name",
-                                   "required":true,
-                                   "type":"string"
-                                }
-                            ],
-                            "responses":{
+                              "responses":{
                                  "200":{
                                     "description":"OK",
                                     "schema":{
@@ -958,6 +994,14 @@ fn test_operation_with_generics() {
                                  }
                               }
                            },
+                           "parameters":[
+                              {
+                                 "in":"path",
+                                 "name":"name",
+                                 "required":true,
+                                 "type":"string"
+                              }
+                           ]
                         }
                      },
                      "swagger":"2.0"
@@ -1071,12 +1115,6 @@ fn test_operations_documentation() {
                     "/pets": {
                       "get": {
                         "description":"Will provide list of all pets available for sale",
-                        "parameters": [{
-                            "format": "int32",
-                            "in": "query",
-                            "name": "limit",
-                            "type": "integer"
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -1090,6 +1128,12 @@ fn test_operations_documentation() {
                         },
                         "summary":"List all pets"
                       },
+                      "parameters": [{
+                        "format": "int32",
+                        "in": "query",
+                        "name": "limit",
+                        "type": "integer"
+                      }]
                     },
                     "/pet": {
                       "get": {
@@ -1367,15 +1411,15 @@ fn test_errors_app() {
                   },
                   "paths": {
                     "/api/echo": {
+                      "parameters": [{
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Pet"
+                        }
+                      }],
                       "post": {
-                        "parameters": [{
-                            "in": "body",
-                            "name": "body",
-                            "required": true,
-                            "schema": {
-                              "$ref": "#/definitions/Pet"
-                            }
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -1524,15 +1568,15 @@ fn test_security_app() {
                   },
                   "paths": {
                     "/api/echo1": {
+                      "parameters": [{
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Pet"
+                        }
+                      }],
                       "post": {
-                        "parameters": [{
-                            "in": "body",
-                            "name": "body",
-                            "required": true,
-                            "schema": {
-                              "$ref": "#/definitions/Pet"
-                            }
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -1549,15 +1593,15 @@ fn test_security_app() {
                       }
                     },
                     "/api/echo2": {
+                      "parameters": [{
+                        "in": "body",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                          "$ref": "#/definitions/Pet"
+                        }
+                      }],
                       "post": {
-                        "parameters": [{
-                            "in": "body",
-                            "name": "body",
-                            "required": true,
-                            "schema": {
-                              "$ref": "#/definitions/Pet"
-                            }
-                          }],
                         "responses": {
                           "200": {
                             "description": "OK",

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -151,15 +151,15 @@ fn test_simple_app() {
                   },
                   "paths": {
                     "/api/echo": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
-                      "post": {
+                    "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                            "$ref": "#/definitions/Pet"
+                            }
+                        }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -171,15 +171,15 @@ fn test_simple_app() {
                       }
                     },
                     "/api/async_echo": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -191,15 +191,15 @@ fn test_simple_app() {
                       }
                     },
                     "/api/async_echo_2": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -361,7 +361,6 @@ fn test_params() {
         ready("")
     }
 
-
     #[api_v2_operation]
     fn post_badge_3(
         _p: web::Path<u32>,
@@ -396,10 +395,10 @@ fn test_params() {
                                 .service(
                                     web::resource("/v/{name}")
                                         .route(web::get().to(get_known_badge_2))
-                                        .route(web::post().to(post_badge_2))
+                                        .route(web::post().to(post_badge_2)),
                                 )
                                 .service(
-                                web::resource("/v")
+                                    web::resource("/v")
                                         .route(web::post().to(post_badge_3))
                                         .route(web::patch().to(patch_badge_3)),
                                 )
@@ -419,155 +418,371 @@ fn test_params() {
             check_json(
                 resp,
                 json!({
-                  "info":{"title":"","version":""},
-                  "definitions": {
-                    "BadgeBody":{
-                      "properties":{
-                        "json": {"description": "JSON value", "type": "object"},
-                        "yaml": {"type": "object"}
-                      }
-                    },
-                    "BadgeBodyPatch":{
-                        "properties":{
-                          "json": {"description": "JSON value", "type": "object"},
+                    "definitions": {
+                        "BadgeBody": {
+                            "properties": {
+                                "json": {
+                                    "description": "JSON value",
+                                    "type": "object"
+                                },
+                                "yaml": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "BadgeBodyPatch": {
+                            "properties": {
+                                "json": {
+                                    "description": "JSON value",
+                                    "type": "object"
+                                }
+                            }
                         }
-                    }
-                  },
-                  "paths": {
-                    "/api/v1/{resource}/v/{name}": {
-                      "delete": {
-                        "responses": {}
-                      },
-                      "get": {
-                        "responses": {}
-                      },
-                      "head": {
-                        "responses": {}
-                      },
-                      "options": {
-                        "responses": {}
-                      },
-                      "parameters": [{
-                        "in": "query",
-                        "name": "color",
-                        "required": true,
-                        "type": "string"
-                      }, {
-                        "in": "path",
-                        "name": "name",
-                        "required": true,
-                        "type": "string"
-                      }, {
-                        "format": "int32",
-                        "in": "query",
-                        "name": "res",
-                        "type": "integer"
-                      }, {
-                        "in": "path",
-                        "name": "resource",
-                        "required": true,
-                        "type": "string"
-                      }],
-                      "patch": {
-                        "responses": {}
-                      },
-                      "post": {
-                        "parameters": [{
-                          "in": "formData",
-                          "name": "data",
-                          "required": true,
-                          "type": "string"
-                        }],
-                        "responses": {}
-                      },
-                      "put": {
-                        "responses": {}
-                      }
                     },
-                    "/api/v2/{resource}/foo": {
-                      "get": {
-                        "responses": {}
-                      },
-                      "parameters": [{
-                        "format": "int32",
-                        "in": "path",
-                        "name": "resource",
-                        "required": true,
-                        "type": "integer"
-                      }]
+                    "info": {
+                        "title": "",
+                        "version": ""
                     },
-                    "/api/v2/{resource}/v/{name}": {
-                      "get": {
-                        "parameters": [{
-                          "in": "query",
-                          "name": "color",
-                          "required": true,
-                          "type": "string"
-                        }, {
-                          "format": "int32",
-                          "in": "query",
-                          "name": "res",
-                          "type": "integer"
-                        }],
-                        "responses": {}
-                      },
-                      "parameters": [{
-                        "in": "path",
-                        "name": "name",
-                        "required": true,
-                        "type": "string"
-                      }, {
-                        "format": "int32",
-                        "in": "path",
-                        "name": "resource",
-                        "required": true,
-                        "type": "integer"
-                      }],
-                      "post": {
-                        "parameters": [{
-                          "in": "body",
-                          "name": "body",
-                          "required": true,
-                          "schema": {
-                            "$ref": "#/definitions/BadgeBody"
-                          }
-                        }],
-                        "responses": {}
-                      }
-                    }
-                  },
-                  "/api/v2/{resource}/v": {
-                    "parameters": [{
-                      "format": "int32",
-                      "in": "path",
-                      "name": "resource",
-                      "required": true,
-                      "type": "integer"
-                    }],
-                    "post": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/BadgeBody"
+                    "paths": {
+                        "/api/v1/{resource}/v/{name}": {
+                            "delete": {
+                                "parameters": [
+                                    {
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "query",
+                                        "name": "color",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "int32",
+                                        "in": "query",
+                                        "name": "res",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            },
+                            "get": {
+                                "parameters": [
+                                    {
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "query",
+                                        "name": "color",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "int32",
+                                        "in": "query",
+                                        "name": "res",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            },
+                            "head": {
+                                "parameters": [
+                                    {
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "query",
+                                        "name": "color",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "int32",
+                                        "in": "query",
+                                        "name": "res",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            },
+                            "options": {
+                                "parameters": [
+                                    {
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "query",
+                                        "name": "color",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "int32",
+                                        "in": "query",
+                                        "name": "res",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            },
+                            "patch": {
+                                "parameters": [
+                                    {
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "query",
+                                        "name": "color",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "int32",
+                                        "in": "query",
+                                        "name": "res",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            },
+                            "post": {
+                                "parameters": [
+                                    {
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "query",
+                                        "name": "color",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "int32",
+                                        "in": "query",
+                                        "name": "res",
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "in": "formData",
+                                        "name": "data",
+                                        "required": true,
+                                        "type": "string"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            },
+                            "put": {
+                                "parameters": [
+                                    {
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "query",
+                                        "name": "color",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "int32",
+                                        "in": "query",
+                                        "name": "res",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            }
+                        },
+                        "/api/v2/{resource}/foo": {
+                            "get": {
+                                "parameters": [
+                                    {
+                                        "format": "int32",
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "integer"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            }
+                        },
+                        "/api/v2/{resource}/v": {
+                            "patch": {
+                                "parameters": [
+                                    {
+                                        "format": "int32",
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "in": "body",
+                                        "name": "body",
+                                        "required": true,
+                                        "schema": {
+                                            "$ref": "#/definitions/BadgeBodyPatch"
+                                        }
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            },
+                            "post": {
+                                "parameters": [
+                                    {
+                                        "format": "int32",
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "in": "body",
+                                        "name": "body",
+                                        "required": true,
+                                        "schema": {
+                                            "$ref": "#/definitions/BadgeBody"
+                                        }
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            }
+                        },
+                        "/api/v2/{resource}/v/{name}": {
+                            "get": {
+                                "parameters": [
+                                    {
+                                        "format": "int32",
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "query",
+                                        "name": "color",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "int32",
+                                        "in": "query",
+                                        "name": "res",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            },
+                            "post": {
+                                "parameters": [
+                                    {
+                                        "format": "int32",
+                                        "in": "path",
+                                        "name": "resource",
+                                        "required": true,
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "in": "path",
+                                        "name": "name",
+                                        "required": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "in": "body",
+                                        "name": "body",
+                                        "required": true,
+                                        "schema": {
+                                            "$ref": "#/definitions/BadgeBody"
+                                        }
+                                    }
+                                ],
+                                "responses": {
+                                }
+                            }
                         }
-                      }],
-                      "responses": {}
                     },
-                    "patch": {
-                        "parameters": [{
-                          "in": "body",
-                          "name": "body",
-                          "required": true,
-                          "schema": {
-                            "$ref": "#/definitions/BadgeBodyPatch"
-                          }
-                        }],
-                        "responses": {}
-                    }
-                  },
-                  "swagger": "2.0"
+                    "swagger": "2.0"
                 }),
             );
         },
@@ -726,19 +941,19 @@ fn test_list_in_out() {
                               }
                             }
                           }
-                        }
+                        },
+                        "parameters": [{
+                            "format": "int32",
+                            "in": "query",
+                            "name": "limit",
+                            "type": "integer"
+                          }, {
+                            "enum": ["Asc", "Desc"],
+                            "in": "query",
+                            "name": "sort",
+                            "type": "string"
+                        }],
                       },
-                      "parameters": [{
-                        "format": "int32",
-                        "in": "query",
-                        "name": "limit",
-                        "type": "integer"
-                      }, {
-                        "enum": ["Asc", "Desc"],
-                        "in": "query",
-                        "name": "sort",
-                        "type": "string"
-                      }],
                     }
                   },
                   "swagger": "2.0"
@@ -851,14 +1066,14 @@ fn test_impl_traits() {
                               }
                             }
                           }
-                        }
+                        },
+                        "parameters": [{
+                            "format": "int32",
+                            "in": "query",
+                            "name": "limit",
+                            "type": "integer"
+                        }]
                       },
-                      "parameters": [{
-                        "format": "int32",
-                        "in": "query",
-                        "name": "limit",
-                        "type": "integer"
-                      }]
                     },
                     "/pet": {
                       "get": {
@@ -968,17 +1183,17 @@ fn test_operation_with_generics() {
                                        "type":"array"
                                     }
                                  }
-                              }
-                           },
-                           "parameters":[
-                              {
-                                 "format":"int64",
-                                 "in":"path",
-                                 "name":"id",
-                                 "required":true,
-                                 "type":"integer"
-                              }
-                           ]
+                              },
+                              "parameters":[
+                                {
+                                   "format":"int64",
+                                   "in":"path",
+                                   "name":"id",
+                                   "required":true,
+                                   "type":"integer"
+                                }
+                             ]
+                          },
                         },
                         "/pet/name/{name}":{
                            "get":{
@@ -992,16 +1207,16 @@ fn test_operation_with_generics() {
                                        "type":"array"
                                     }
                                  }
-                              }
-                           },
-                           "parameters":[
-                              {
-                                 "in":"path",
-                                 "name":"name",
-                                 "required":true,
-                                 "type":"string"
-                              }
-                           ]
+                              },
+                              "parameters":[
+                                {
+                                   "in":"path",
+                                   "name":"name",
+                                   "required":true,
+                                   "type":"string"
+                                }
+                             ]
+                          },
                         }
                      },
                      "swagger":"2.0"
@@ -1126,14 +1341,14 @@ fn test_operations_documentation() {
                             }
                           }
                         },
-                        "summary":"List all pets"
+                        "summary":"List all pets",
+                        "parameters": [{
+                            "format": "int32",
+                            "in": "query",
+                            "name": "limit",
+                            "type": "integer"
+                        }]
                       },
-                      "parameters": [{
-                        "format": "int32",
-                        "in": "query",
-                        "name": "limit",
-                        "type": "integer"
-                      }]
                     },
                     "/pet": {
                       "get": {
@@ -1411,15 +1626,15 @@ fn test_errors_app() {
                   },
                   "paths": {
                     "/api/echo": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -1568,15 +1783,15 @@ fn test_security_app() {
                   },
                   "paths": {
                     "/api/echo1": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",
@@ -1593,15 +1808,15 @@ fn test_security_app() {
                       }
                     },
                     "/api/echo2": {
-                      "parameters": [{
-                        "in": "body",
-                        "name": "body",
-                        "required": true,
-                        "schema": {
-                          "$ref": "#/definitions/Pet"
-                        }
-                      }],
                       "post": {
+                        "parameters": [{
+                            "in": "body",
+                            "name": "body",
+                            "required": true,
+                            "schema": {
+                              "$ref": "#/definitions/Pet"
+                            }
+                          }],
                         "responses": {
                           "200": {
                             "description": "OK",


### PR DESCRIPTION
This PR fixes issue and one nit related to shared parameters generation:

- body is usually unique per method, hence do not generalize on body (e.g. patch has all fields optional)

- do not generalize when path has single method. also this generalized parameters feature nevertheless is part of a spec having some issues with some renderers, like redoc.