### PR TITLE
Deps: allow also actix-web 3.0 in addition to 2.0 (for v0.4.*)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ once_cell = "1.4.0"
 [dev-dependencies]
 actix-rt = "1.0"
 actix-service = "1.0"
-actix-web = "2.0"
+actix-web = ">=2.0,<4"
 chrono_dev = { version = "0.4", features = ["serde"], package = "chrono" }
 futures = "0.3"
 uuid_dev = { version = "0.8", features = ["serde"], package = "uuid" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,8 @@ homepage = "https://github.com/wafflespeanut/paperclip"
 repository = "https://github.com/wafflespeanut/paperclip"
 
 [dependencies]
-actix-web = { version = "2.0", optional = true }
-actix-http = { version = "1.0", optional = true }
+actix-web = { version = ">=2.0,<4", optional = true }
+actix-http = { version = ">=1.0,<3", optional = true }
 actix-multipart = { version = "0", optional = true }
 chrono = { version = "0", optional = true }
 heck = { version = "0.3", optional = true }

--- a/plugins/actix-web/Cargo.toml
+++ b/plugins/actix-web/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/wafflespeanut/paperclip"
 [dependencies]
 futures = "0.3"
 actix-service = "1.0"
-actix-web = "2.0"
+actix-web = ">=2.0,<4"
 paperclip-core = { path = "../../core", version = "0.3.0", features = ["actix"] }
 paperclip-macros = { path = "../../macros", version = "0.4.0", features = ["actix"] }
 parking_lot = ">=0.10,<0.12"


### PR DESCRIPTION
Actix 3.0 has been recently released. It seems that paperclip (v0.4.1)
builds just fine against both actix-web 2.0 and 3.0
(and their dependent libs).

So just relax the dependency and let downstream crates choose which major
version of actix they pull.

I've tested this with downstream crates requiring both actix 2.0 and crates requiring 3.0,
works wel. YMMV.

This change is based (in git sense) on v0.4.1 tag rather than current master. Current master seems to contain feature changes to be released as v0.5. It would be cool if actix 3.0 support can be released earlier as v0.4.2 (v0.2.2). If you'd create a branch out of v0.4.1 (or a some later commit still slated for "stable" 0.4 branch), I'll change target of this PR and it should apply cleanly.