### PR TITLE
Actix operation macros to support tags and info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Actix plugin: `#[api_v2_operation]` macro now supports specifying `consumes`, `produces`, `summary`, `description`
+- Actix plugin: `#[api_v2_operation]` macro now supports specifying `consumes`, `produces`, `summary`, `description`, `tags`
 and `operation_id` in macro.
 - Actix plugin: Support for actix-web 3.0.
+- Actix plugin: `App::wrap_api_with_spec` allows to provide default specification with `info` and other custom settings
 
 ### Changed
 - Actix plugin: Internals of `#[api_v2_operation]` proc macro (long-outstanding technical debt). This now generates operation metadata (on the fly) for each handler, which enables us to tie custom changes to operations easily.

--- a/book/actix-plugin.md
+++ b/book/actix-plugin.md
@@ -199,6 +199,7 @@ This can be overridden by explicitly specifying `summary` and `description` in t
   operation_id = "my_handler",
   consumes = "application/yaml, application/json",
   produces = "application/yaml, application/json",
+  tags(Cats, Dogs),
 )]
 async fn my_handler() -> Json<Foo> { /* */ }
 ```
@@ -295,6 +296,43 @@ struct OAuth2Access;
 #[openapi(parent = "OAuth2Access", scopes("pets.read", "pets.write"))]
 struct PetScopeAccess;
 ```
+
+#### Defining application level schema defaults
+
+It is possible to define default initial values for the schema, which might be useful to define "info",
+"schemes", "tags" and other top level schema fields which are not inherited from handlers.
+
+```rust
+let mut spec = DefaultApiRaw::default();
+spec.tags = vec![
+    Tag {
+        name: "Dogs".to_string(),
+        description: Some("Images of dogs".to_string()),
+        external_docs: None,
+    },
+    Tag {
+        name: "Cats".to_string(),
+        description: Some("Images of cats".to_string()),
+        external_docs: None,
+    },
+    Tag {
+        name: "Cars".to_string(),
+        description: Some("Images of nice cars".to_string()),
+        external_docs: None,
+    },
+];
+spec.info = Info {
+    version: "0.1".into(),
+    title: "Image server".into(),
+    ..Default::default()
+};
+App::new()
+    .wrap_api_with_spec(spec)
+    .with_json_spec_at("/api/spec")
+    .service(web::resource("/images/pets").route(web::get().to(some_pets_images)))
+    .build()
+```
+
 
 #### Known limitations
 

--- a/core/src/v2/models.rs
+++ b/core/src/v2/models.rs
@@ -624,6 +624,8 @@ pub struct Operation<P, R> {
     pub parameters: Vec<Either<Reference, P>>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub deprecated: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 impl<S> Operation<Parameter<S>, Response<S>> {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/wafflespeanut/paperclip"
 proc-macro = true
 
 [dependencies]
+mime = "0.3"
 proc-macro2 = "1.0"
 proc-macro-error = "1.0"
 quote = "1.0"

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -277,6 +277,22 @@ fn parse_operation_attrs(attrs: TokenStream) -> (Vec<Ident>, Vec<proc_macro2::To
                             )
                         }
                     }
+                    "tags" => {
+                        if let Lit::Str(tags) = lit {
+                            let tags = tags.value();
+                            let tags: Vec<_> = tags.split(',').collect();
+                            if !tags.is_empty() {
+                                params.push(ident.clone());
+                                values.push(quote!(vec![#( #tags.to_string() ),*]));
+                            }
+                        } else {
+                            emit_error!(
+                                lit.span(),
+                                "Expected comma separated list of tags in string literal: {:?}",
+                                lit
+                            )
+                        }
+                    }
                     x => emit_error!(ident.span(), "Unknown attribute {}", x),
                 }
             } else {

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -116,7 +116,7 @@ pub fn emit_v2_operation(attrs: TokenStream, input: TokenStream) -> TokenStream 
     } else if is_impl_trait {
         quote!((|| #block)())
     } else {
-        quote!((|| async #block)())
+        quote!(async move #block)
     };
 
     item_ast.block = Box::new(

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -11,8 +11,8 @@ use syn::spanned::Spanned;
 use syn::{
     punctuated::{Pair, Punctuated},
     Attribute, Data, DataEnum, DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed, FnArg,
-    Generics, Ident, ItemFn, Lit, Meta, NestedMeta, PathArguments, ReturnType, Token, TraitBound,
-    Type, TypeTraitObject,
+    Generics, Ident, ItemFn, Lit, Meta, MetaNameValue, NestedMeta, PathArguments, ReturnType,
+    Token, TraitBound, Type, TypeTraitObject,
 };
 
 use std::collections::HashMap;
@@ -37,42 +37,18 @@ pub fn emit_v2_operation(attrs: TokenStream, input: TokenStream) -> TokenStream 
         }
     };
 
-    let _attrs = crate::parse_input_attrs(attrs);
-    // TODO: summary and description
-
     // Unit struct
     let s_name = format!("paperclip_{}", item_ast.sig.ident);
     let unit_struct = Ident::new(&s_name, default_span);
     let generics = &item_ast.sig.generics;
     let (mut struct_generics, mut generics_call) = (quote!(), quote!());
     let mut struct_definition = quote!(struct #unit_struct;);
-    if !generics.params.is_empty() {
-        let params: Punctuated<Ident, _> = generics
-            .params
-            .pairs()
-            .filter_map(|pair| match pair {
-                Pair::Punctuated(syn::GenericParam::Type(gen), punct) => {
-                    Some(Pair::new(gen.ident.clone(), Some(*punct)))
-                }
-                Pair::End(syn::GenericParam::Type(gen)) => Some(Pair::new(gen.ident.clone(), None)),
-                _ => None,
-            })
-            .collect();
-        generics_call = quote!(::<#params> { p: std::marker::PhantomData });
-        struct_generics = quote!(<#params>);
-        struct_definition =
-            quote!(struct #unit_struct <#params> { p: std::marker::PhantomData<(#params)> } )
+    let generics_params = extract_generics_params(&item_ast);
+    if !generics_params.is_empty() {
+        generics_call = quote!(::<#generics_params> { p: std::marker::PhantomData });
+        struct_generics = quote!(<#generics_params>);
+        struct_definition = quote!(struct #unit_struct <#generics_params> { p: std::marker::PhantomData<(#generics_params)> } )
     }
-
-    let modifiers = item_ast
-        .sig
-        .inputs
-        .iter()
-        .filter_map(|inp| match inp {
-            FnArg::Receiver(_) => None,
-            FnArg::Typed(ref t) => Some(&t.ty),
-        })
-        .collect::<Vec<_>>();
 
     // Get rid of async prefix. In the end, we'll have them all as `impl Future` thingies.
     if item_ast.sig.asyncness.is_some() {
@@ -156,24 +132,23 @@ pub fn emit_v2_operation(attrs: TokenStream, input: TokenStream) -> TokenStream 
         .expect("parsing wrapped block"),
     );
 
-    let docs = extract_documentation(&item_ast.attrs);
-    let lines = docs.lines();
-    let mut before_empty = true;
-    let (summary, description): (Vec<_>, Vec<_>) = lines.partition(|line| {
-        if line.trim().is_empty() {
-            before_empty = false
-        };
-        before_empty
-    });
-    let none_if_empty = |text: &str| {
-        if text.is_empty() {
-            quote!(None)
-        } else {
-            quote!(Some(#text.to_string()))
+    // Initialize operation parameters from macro attributes
+    let (mut op_params, mut op_values) = parse_operation_attrs(attrs);
+
+    // Optionally extract summary and description from doc comments
+    if op_params.iter().find(|i| *i == "summary").is_none() {
+        let (summary, description) = extract_fn_documentation(&item_ast);
+        if let Some(summary) = summary {
+            op_params.push(Ident::new("summary", item_ast.span()));
+            op_values.push(summary)
         }
-    };
-    let summary = none_if_empty(summary.into_iter().collect::<String>().trim());
-    let description = none_if_empty(description.into_iter().collect::<String>().trim());
+        if let Some(description) = description {
+            op_params.push(Ident::new("description", item_ast.span()));
+            op_values.push(description)
+        }
+    }
+
+    let modifiers = extract_fn_arguments_types(&item_ast);
 
     quote!(
         #struct_definition
@@ -184,8 +159,9 @@ pub fn emit_v2_operation(attrs: TokenStream, input: TokenStream) -> TokenStream 
             fn operation() -> paperclip::v2::models::DefaultOperationRaw {
                 use paperclip::actix::OperationModifier;
                 let mut op = paperclip::v2::models::DefaultOperationRaw::default();
-                op.summary = #summary;
-                op.description = #description;
+                #(
+                    op.#op_params = #op_values;
+                )*
                 #(
                     <#modifiers>::update_parameter(&mut op);
                     <#modifiers>::update_security(&mut op);
@@ -217,6 +193,98 @@ pub fn emit_v2_operation(attrs: TokenStream, input: TokenStream) -> TokenStream 
     )
     // );
     .into()
+}
+
+// Extract punctuated generic parameters from fn definition
+fn extract_generics_params(item_ast: &ItemFn) -> Punctuated<Ident, syn::token::Comma> {
+    item_ast
+        .sig
+        .generics
+        .params
+        .pairs()
+        .filter_map(|pair| match pair {
+            Pair::Punctuated(syn::GenericParam::Type(gen), punct) => {
+                Some(Pair::new(gen.ident.clone(), Some(*punct)))
+            }
+            Pair::End(syn::GenericParam::Type(gen)) => Some(Pair::new(gen.ident.clone(), None)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Extract function arguments
+fn extract_fn_arguments_types(item_ast: &ItemFn) -> Vec<Type> {
+    item_ast
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|inp| match inp {
+            FnArg::Receiver(_) => None,
+            FnArg::Typed(ref t) => Some(*t.ty.clone()),
+        })
+        .collect()
+}
+
+/// Parse macro attrs, matching to Operation fields
+/// Returning operation attribute identifier and value initialization arrays
+fn parse_operation_attrs(attrs: TokenStream) -> (Vec<Ident>, Vec<proc_macro2::TokenStream>) {
+    let attrs = crate::parse_input_attrs(attrs);
+    let mut params = Vec::new();
+    let mut values = Vec::new();
+    for attr in attrs.0 {
+        if let NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit, .. })) = &attr {
+            if let Some(ident) = path.get_ident() {
+                match ident.to_string().as_str() {
+                    "summary" | "description" | "operation_id" => {
+                        if let Lit::Str(val) = lit {
+                            params.push(ident.clone());
+                            values.push(quote!(#val.to_string()));
+                        } else {
+                            emit_error!(lit.span(), "Expected string literal: {:?}", lit)
+                        }
+                    }
+                    x => emit_error!(ident.span(), "Unknown attribute {}", x),
+                }
+            } else {
+                emit_error!(
+                    path.span(),
+                    "Expected single identifier, got path {:?}",
+                    path
+                )
+            }
+        } else {
+            emit_error!(attr.span(), "Not supported attribute type {:?}", attr)
+        }
+    }
+    (params, values)
+}
+
+/// Extracts summary from top line doc comment and description from the rest
+fn extract_fn_documentation(
+    item_ast: &ItemFn,
+) -> (
+    Option<proc_macro2::TokenStream>,
+    Option<proc_macro2::TokenStream>,
+) {
+    let docs = extract_documentation(&item_ast.attrs);
+    let lines = docs.lines();
+    let mut before_empty = true;
+    let (summary, description): (Vec<_>, Vec<_>) = lines.partition(|line| {
+        if line.trim().is_empty() {
+            before_empty = false
+        };
+        before_empty
+    });
+    let none_if_empty = |text: &str| {
+        if text.is_empty() {
+            None
+        } else {
+            Some(quote!(Some(#text.to_string())))
+        }
+    };
+    let summary = none_if_empty(summary.into_iter().collect::<String>().trim());
+    let description = none_if_empty(description.into_iter().collect::<String>().trim());
+    (summary, description)
 }
 
 /// Actual parser and emitter for `api_v2_errors` macro.

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -191,11 +191,10 @@ pub fn emit_v2_operation(attrs: TokenStream, input: TokenStream) -> TokenStream 
             }
         }
     )
-    // );
     .into()
 }
 
-// Extract punctuated generic parameters from fn definition
+/// Extract punctuated generic parameters from fn definition
 fn extract_generics_params(item_ast: &ItemFn) -> Punctuated<Ident, syn::token::Comma> {
     item_ast
         .sig
@@ -240,7 +239,7 @@ fn parse_operation_attrs(attrs: TokenStream) -> (Vec<Ident>, Vec<proc_macro2::To
                     "summary" | "description" | "operation_id" => {
                         if let Lit::Str(val) = lit {
                             params.push(ident.clone());
-                            values.push(quote!(#val.to_string()));
+                            values.push(quote!(Some(#val.to_string())));
                         } else {
                             emit_error!(lit.span(), "Expected string literal: {:?}", lit)
                         }
@@ -263,11 +262,11 @@ fn parse_operation_attrs(attrs: TokenStream) -> (Vec<Ident>, Vec<proc_macro2::To
                             if !mime_types.is_empty() {
                                 params.push(ident.clone());
                                 values.push(quote!({
-                                    let tmp = std::collections::BTreeSet::new();
+                                    let mut tmp = std::collections::BTreeSet::new();
                                     #(
                                         tmp.insert(#mime_types);
                                     )*
-                                    tmp
+                                    Some(tmp)
                                 }));
                             }
                         } else {

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -10,7 +10,7 @@ use actix_web::{web::HttpResponse, Error};
 use futures::future::{ok as fut_ok, Ready};
 use paperclip_core::v2::models::{
     DefaultApiRaw, DefaultOperationRaw, DefaultPathItemRaw, DefaultSchemaRaw, HttpMethod,
-    SecurityScheme,
+    SecurityScheme, Tag,
 };
 use parking_lot::RwLock;
 
@@ -284,6 +284,13 @@ where
                 map.normalize();
             }
         }
+    }
+
+    /// Updates list of tags in specification
+    /// Tags might be referenced from Operation::tags by name
+    pub fn set_tags(self, tags: Vec<Tag>) -> Self {
+        self.spec.write().tags = tags;
+        self
     }
 }
 

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 use paperclip::actix::{
     api_v2_errors, api_v2_operation, web, Apiv2Schema, Apiv2Security, OpenApiExt,
 };
-use paperclip::v2::models::Tag;
+use paperclip::v2::models::{DefaultApiRaw, Info, Tag};
 use parking_lot::Mutex;
 
 use std::collections::{BTreeMap, HashSet};
@@ -1010,25 +1010,32 @@ fn test_tags() {
 
     run_and_check_app(
         || {
+            let mut spec = DefaultApiRaw::default();
+            spec.tags = vec![
+                Tag {
+                    name: "dogs".to_string(),
+                    description: Some("Images of dogs".to_string()),
+                    external_docs: None,
+                },
+                Tag {
+                    name: "cats".to_string(),
+                    description: Some("Images of cats".to_string()),
+                    external_docs: None,
+                },
+                Tag {
+                    name: "cars".to_string(),
+                    description: Some("Images of nice cars".to_string()),
+                    external_docs: None,
+                },
+            ];
+            spec.info = Info {
+                version: "0.1".into(),
+                title: "Image server".into(),
+                ..Default::default()
+            };
+
             App::new()
-                .wrap_api()
-                .set_tags(vec![
-                    Tag {
-                        name: "dogs".to_string(),
-                        description: Some("Images of dogs".to_string()),
-                        external_docs: None,
-                    },
-                    Tag {
-                        name: "cats".to_string(),
-                        description: Some("Images of cats".to_string()),
-                        external_docs: None,
-                    },
-                    Tag {
-                        name: "cars".to_string(),
-                        description: Some("Images of nice cars".to_string()),
-                        external_docs: None,
-                    },
-                ])
+                .wrap_api_with_spec(spec)
                 .with_json_spec_at("/api/spec")
                 .service(web::resource("/images/pets").route(web::get().to(some_pets_images)))
                 .build()
@@ -1060,8 +1067,8 @@ fn test_tags() {
                         }
                     },
                     "info":{
-                        "title":"",
-                        "version":""
+                        "title":"Image server",
+                        "version":"0.1"
                     },
                     "paths":{
                         "/images/pets":{

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -1299,7 +1299,7 @@ fn test_tags() {
         id: u64,
     }
 
-    #[api_v2_operation(tags = "cats,dogs")]
+    #[api_v2_operation(tags(Cats, Dogs))]
     fn some_pets_images() -> impl Future<Output = web::Json<Vec<Image>>> {
         ready(web::Json(Vec::new()))
     }
@@ -1309,17 +1309,17 @@ fn test_tags() {
             let mut spec = DefaultApiRaw::default();
             spec.tags = vec![
                 Tag {
-                    name: "dogs".to_string(),
+                    name: "Dogs".to_string(),
                     description: Some("Images of dogs".to_string()),
                     external_docs: None,
                 },
                 Tag {
-                    name: "cats".to_string(),
+                    name: "Cats".to_string(),
                     description: Some("Images of cats".to_string()),
                     external_docs: None,
                 },
                 Tag {
-                    name: "cars".to_string(),
+                    name: "Cars".to_string(),
                     description: Some("Images of nice cars".to_string()),
                     external_docs: None,
                 },
@@ -1380,10 +1380,7 @@ fn test_tags() {
                                     }
                                 }
                                 },
-                                "tags":[
-                                "cats",
-                                "dogs"
-                                ]
+                                "tags":[ "Cats", "Dogs" ]
                             }
                         }
                     },
@@ -1391,15 +1388,15 @@ fn test_tags() {
                     "tags":[
                         {
                             "description":"Images of dogs",
-                            "name":"dogs"
+                            "name":"Dogs"
                         },
                         {
                             "description":"Images of cats",
-                            "name":"cats"
+                            "name":"Cats"
                         },
                         {
                             "description":"Images of nice cars",
-                            "name":"cars"
+                            "name":"Cars"
                         }
                     ]
                 }),


### PR DESCRIPTION
Built on top of #217 this change allows to configure list of tags, info and other Api specification defaults when using actix plugin. I believe this closes the loop to be able to build a nice looking spec, e.g. allowing to render APIs grouped by categories:

<img width="774" alt="Screenshot 2020-09-16 at 18 54 40" src="https://user-images.githubusercontent.com/1453344/93362718-fd5ba280-f84e-11ea-925b-a00c12a3811c.png">

To configure default I initially thought to add methods to App, but it is safer to configure defaults right when Api wrapper is created. Hence I've extended trait with additional method. This should provide full back compatibility.:

```
            let mut spec = DefaultApiRaw::default();
            spec.tags = vec![
              Tag {
                  name: "Dogs".to_string(),
                  description: Some("Images of dogs".to_string()),
                  external_docs: None,
              },
              Tag {
                  name: "Cats".to_string(),
                  description: Some("Images of cats".to_string()),
                  external_docs: None,
              },
              Tag {
                  name: "Cars".to_string(),
                  description: Some("Images of nice cars".to_string()),
                  external_docs: None,
              },
          ];
          spec.info = Info {
            version: "0.1".into(), 
            title: "Image server".into(), 
            ..Default::default()
          };

            App::new()
                .wrap_api_with_spec(spec)
                .with_json_spec_at("/api/spec")
                .service(web::resource("/images/pets").route(web::get().to(some_pets_images)))
                .build()
```

Tags supported by Operation and api_v2_operation macros:
```
    #[api_v2_operation(tags(Cats,Dogs))]
    fn some_pets_images() -> impl Future<Output = web::Json<Vec<Image>>> {
        ready(web::Json(Vec::new()))
    }
```