### PR TITLE
Remove object type from json and yaml Values

### DIFF
--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -182,8 +182,7 @@ impl_type_simple!(isize, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(u64, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(u128, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(usize, DataType::Integer, DataTypeFormat::Int64);
-impl_type_simple!(serde_json::Value, DataType::Object);
-impl_type_simple!(serde_yaml::Value, DataType::Object);
+
 #[cfg(feature = "actix-multipart")]
 impl_type_simple!(
     actix_multipart::Multipart,
@@ -269,6 +268,8 @@ pub trait Apiv2Schema {
 }
 
 impl Apiv2Schema for () {}
+impl Apiv2Schema for serde_json::Value {}
+impl Apiv2Schema for serde_yaml::Value {}
 
 impl<T: TypedData> Apiv2Schema for T {
     fn raw_schema() -> DefaultSchemaRaw {

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -443,10 +443,8 @@ fn test_params() {
                             "properties": {
                                 "json": {
                                     "description": "JSON value",
-                                    "type": "object"
                                 },
                                 "yaml": {
-                                    "type": "object"
                                 }
                             }
                         },
@@ -454,7 +452,6 @@ fn test_params() {
                             "properties": {
                                 "json": {
                                     "description": "JSON value",
-                                    "type": "object"
                                 }
                             }
                         }


### PR DESCRIPTION
I'm not sure if this is more correct, but it feels more correct to me. Out of all of the variants of `serde_json::Value` only one of them is an `object`.

Closes #235 