### PR TITLE
Document more complex parameters in actix plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ matrix:
   include:
   - name: test
     script:
-    - cargo test --all --features "actix cli chrono uuid"
+    - cargo test --all --features "actix cli"
+    - cargo test --all --features "actix cli chrono serde_qs uuid"
     - cd tests/test_k8s && cargo check
     - cd ../test_pet && cargo check
     - cd cli && CARGO_TARGET_DIR=../target cargo check
@@ -19,7 +20,7 @@ matrix:
     - rustup toolchain install nightly
     - rustup default nightly
     script:
-    - cargo test --all --features "actix-nightly cli chrono uuid"
+    - cargo test --all --features "actix-nightly cli chrono serde_qs uuid"
   - name: build
     script:
     - cargo build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
   include:
   - name: test
     script:
-    - cargo test --all --features "actix cli"
-    - cargo test --all --features "actix cli chrono serde_qs uuid"
+    - cargo test --all --features "actix3 cli"
+    - cargo test --all --features "actix3 cli chrono serde_qs uuid"
     - cd tests/test_k8s && cargo check
     - cd ../test_pet && cargo check
     - cd cli && CARGO_TARGET_DIR=../target cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ reqwest = { version = "0.10", features = ["blocking", "json"] }
 log = { version = "0.4", features = ["kv_unstable"] }
 insta = "1.0"
 env_logger = "0.8"
-serde_qs_test = { package = "serde_qs", version = "0.8.1", features = ["actix"] }
+serde_qs_dev = { version = "0.8", package = "serde_qs", features = ["actix"] }
 
 [features]
 # actix-web support
@@ -96,4 +96,4 @@ required-features = ["v2", "codegen"]
 
 [[test]]
 name = "test_app"
-required-features = ["cli", "actix", "uuid", "chrono"]
+required-features = ["cli", "actix3", "uuid", "chrono"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ reqwest = { version = "0.10", features = ["blocking", "json"] }
 log = { version = "0.4", features = ["kv_unstable"] }
 insta = "1.0"
 env_logger = "0.8"
+serde_qs_test = { package = "serde_qs", version = "0.8.1", features = ["actix"] }
 
 [features]
 # actix-web support

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build:
 	cargo build --features cli
 
 test:
-	cargo test --all --features "actix cli chrono uuid"
+	cargo test --all --features "actix cli chrono serde_qs uuid"
 	# Compile the code generated through tests.
 	cd tests/test_pet && cargo check
 	cd tests/test_pet/cli && CARGO_TARGET_DIR=../target cargo check

--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -347,11 +347,14 @@ macro_rules! impl_param_extractor ({ $ty:ty => $container:ident } => {
 
 fn map_schema_to_items(schema: &DefaultSchemaRaw) -> Items {
     Items {
-        data_type: schema.data_type.clone(),
+        data_type: schema.data_type,
         format: schema.format.clone(),
         collection_format: None, // this defaults to csv
         enum_: schema.enum_.clone(),
-        items: schema.items.as_deref().map(|schema| Box::new(map_schema_to_items(schema))),
+        items: schema
+            .items
+            .as_deref()
+            .map(|schema| Box::new(map_schema_to_items(schema))),
         ..Default::default() // range fields are not emitted
     }
 }

--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -332,6 +332,7 @@ macro_rules! impl_param_extractor ({ $ty:ty => $container:ident } => {
                     format: v.format,
                     enum_: v.enum_,
                     description: v.description,
+                    collection_format: None, // this defaults to csv
                     items: v.items.as_deref().map(map_schema_to_items),
                     name: k,
                     ..Default::default()
@@ -442,6 +443,7 @@ fn serde_qs_params(
                         collection_format: Some(CollectionFormat::Multi),
                         ..Default::default() // range fields are not emitted
                     }),
+                    collection_format: Some(CollectionFormat::Multi),
                     ..Default::default() // range fields are not emitted
                 }))
             }

--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -2,8 +2,8 @@
 use super::schema::TypedData;
 use super::{
     models::{
-        DefaultOperationRaw, DefaultResponseRaw, DefaultSchemaRaw, Either, Parameter, ParameterIn,
-        Response, SecurityScheme,
+        DefaultOperationRaw, DefaultResponseRaw, DefaultSchemaRaw, Either, Items, Parameter,
+        ParameterIn, Response, SecurityScheme,
     },
     schema::{Apiv2Errors, Apiv2Operation, Apiv2Schema},
 };
@@ -324,11 +324,20 @@ macro_rules! impl_param_extractor ({ $ty:ty => $container:ident } => {
                 op.parameters.push(Either::Right(Parameter {
                     in_: ParameterIn::$container,
                     required: def.required.contains(&k),
-                    name: k,
                     data_type: v.data_type,
                     format: v.format,
                     enum_: v.enum_,
                     description: v.description,
+                    items: v.items.as_ref().map(|schema| {
+                        Items {
+                            data_type: schema.data_type.clone(),
+                            format: schema.format.clone(),
+                            // collection_format, // this defaults to csv
+                            enum_: schema.enum_.clone(),
+                            ..Default::default() // range fields are not emitted
+                        }
+                    }),
+                    name: k,
                     ..Default::default()
                 }));
             }

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -169,12 +169,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse,
-                Error = Error,
-                InitError = (),
-            > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.take().map(|a| a.default_service(f));

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -59,12 +59,12 @@ impl Resource {
 impl<T> HttpServiceFactory for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse,
+        Error = Error,
+        InitError = (),
+    > + 'static,
 {
     fn register(self, config: &mut AppService) {
         self.inner.register(config)
@@ -74,12 +74,12 @@ where
 impl<T> IntoServiceFactory<T> for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse,
+        Error = Error,
+        InitError = (),
+    > + 'static,
 {
     fn into_factory(self) -> T {
         self.inner.into_factory()
@@ -242,12 +242,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse,
-                Error = Error,
-                InitError = (),
-            > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.default_service(f);
@@ -302,12 +302,12 @@ impl Scope {
 impl<T> HttpServiceFactory for Scope<actix_web::Scope<T>>
 where
     T: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse,
+        Error = Error,
+        InitError = (),
+    > + 'static,
 {
     fn register(self, config: &mut AppService) {
         if let Some(s) = self.inner {
@@ -382,12 +382,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse,
-                Error = Error,
-                InitError = (),
-            > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.map(|s| s.default_service(f));

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -2091,12 +2091,12 @@ fn test_multiple_method_routes() {
         F: Fn() -> App<T, B> + Clone + Send + Sync + 'static,
         B: MessageBody + 'static,
         T: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse<B>,
-                Error = Error,
-                InitError = (),
-            > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse<B>,
+            Error = Error,
+            InitError = (),
+        > + 'static,
     {
         run_and_check_app(f, |addr| {
             let resp = CLIENT
@@ -2683,12 +2683,12 @@ where
     F: Fn() -> App<T, B> + Clone + Send + Sync + 'static,
     B: MessageBody + 'static,
     T: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse<B>,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse<B>,
+        Error = Error,
+        InitError = (),
+    > + 'static,
     G: Fn(String) -> U,
 {
     let (tx, rx) = mpsc::channel();

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -2573,6 +2573,7 @@ fn test_security_app() {
 
 #[test]
 #[allow(dead_code)]
+#[cfg(serde_qs)]
 fn test_serde_qs_app() {
     use serde_qs_test::actix::QsQuery;
     /// For testing serde_qs query params

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -2571,12 +2571,12 @@ fn test_security_app() {
     );
 }
 
+#[cfg(feature = "serde_qs")]
 #[test]
-#[allow(dead_code)]
-#[cfg(serde_qs)]
 fn test_serde_qs_app() {
-    use serde_qs_test::actix::QsQuery;
+    use serde_qs_dev::actix::QsQuery;
     /// For testing serde_qs query params
+    #[allow(dead_code)]
     #[derive(Deserialize, Apiv2Schema)]
     struct QueryParams {
         id: u8,
@@ -2586,6 +2586,7 @@ fn test_serde_qs_app() {
         user_ids: Vec<u8>,
     }
 
+    #[allow(dead_code)]
     #[derive(Deserialize, Apiv2Schema)]
     struct Address {
         city: String,

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -2658,12 +2658,13 @@ fn test_serde_qs_app() {
                                         "type": "integer"
                                     },
                                     {
+                                        "collectionFormat": "multi",
                                         "in": "query",
                                         "items": {
                                             "collectionFormat": "multi",
                                             "format": "int32",
                                             "type": "integer"
-                                        },
+                                          },
                                         "name": "user_ids[]",
                                         "type": "array"
                                     }

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -354,7 +354,7 @@ fn test_params() {
     #[derive(Deserialize, Apiv2Schema)]
     struct BadgeParams {
         res: Option<u16>,
-        color: String,
+        colors: Vec<String>,
     }
 
     #[derive(Deserialize, Apiv2Schema)]
@@ -531,9 +531,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -561,9 +564,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -591,9 +597,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -621,9 +630,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -651,9 +663,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -681,9 +696,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -717,9 +735,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -809,9 +830,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",


### PR DESCRIPTION
Attempt at fixing #239 and #265 

For usage of `serde_qs::QsQuery<T>`, this will descend the tree of `T` and document each primitive or array as a separate parameter with the name given by it's location in the tree in the qs format, eg. `user[phone_number][mobile]`. The main limitaion is that an array cannot contain an object, only primitives - this is because an array of primitives can be identified without array indicies which would require a parameter in the name - and openapi doesn't support that.

For other parameters this change also adds the `.items` parameter of the `ParameterObject` and is generated recursively.