### PR TITLE
Add Json and Yaml types

### DIFF
--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -185,6 +185,8 @@ impl_type_simple!(isize, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(u64, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(u128, DataType::Integer, DataTypeFormat::Int64);
 impl_type_simple!(usize, DataType::Integer, DataTypeFormat::Int64);
+impl_type_simple!(serde_json::Value, DataType::String);
+impl_type_simple!(serde_yaml::Value, DataType::String);
 
 #[cfg(feature = "actix-multipart")]
 impl_type_simple!(
@@ -287,8 +289,6 @@ pub trait Apiv2Schema {
 }
 
 impl Apiv2Schema for () {}
-impl Apiv2Schema for serde_json::Value {}
-impl Apiv2Schema for serde_yaml::Value {}
 
 impl<T: TypedData> Apiv2Schema for T {
     fn raw_schema() -> DefaultSchemaRaw {

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -39,7 +39,7 @@ mod template {
         ",
         );
         contents.push_str(&name);
-        contents.push_str(",");
+        contents.push(',');
     }
 
     contents.push_str(

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -486,8 +486,10 @@ fn test_params() {
                             "properties": {
                                 "json": {
                                     "description": "JSON value",
+                                    "type":"string"
                                 },
                                 "yaml": {
+                                    "type":"string"
                                 }
                             },
                             "type":"object"
@@ -496,6 +498,7 @@ fn test_params() {
                             "properties": {
                                 "json": {
                                     "description": "JSON value",
+                                    "type":"string"
                                 }
                             },
                             "type":"object"


### PR DESCRIPTION
The current generated code for Jsons and Yamls are wrong. Since there is no specifc type for these formats in OpenApi, they should be "string". (Am I right?)

So for the following struct:

```
struct Pet {
    name: String,
    detail: Option<Jsonb>,
    id: Option<i64>,
}
```

Instead of this (notice the _detail_ field):

```
{
	"definitions": {
		"Pet": {
			"type": "object",
			"properties": {
				"detail": {},
				"id": {
					"type": "integer",
					"format": "int64"
				},
				"name": {
					"type": "string"
				}
			},
			"required": ["name"]
		}
	}
}
```

It will generate this:
```
{
	"definitions": {
		"Pet": {
			"type": "object",
			"properties": {
				"detail": {
					"type": "string"
				},
				"id": {
					"type": "integer",
					"format": "int64"
				},
				"name": {
					"type": "string"
				}
			},
			"required": ["name"]
		}
	}
}
```