### PR TITLE
Add NaiveTime type for actix plugin

### DIFF
--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -202,6 +202,8 @@ impl_type_simple!(
 );
 #[cfg(feature = "chrono")]
 impl_type_simple!(chrono::NaiveDate, DataType::String, DataTypeFormat::Date);
+#[cfg(feature = "chrono")]
+impl_type_simple!(chrono::NaiveTime, DataType::String);
 #[cfg(feature = "rust_decimal")]
 impl_type_simple!(
     rust_decimal::Decimal,

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -39,7 +39,7 @@ mod template {
         ",
         );
         contents.push_str(&name);
-        contents.push_str(",");
+        contents.push(',');
     }
 
     contents.push_str(


### PR DESCRIPTION
Add the last of `chrono`s dat and time types.
The spec doesn't have a format for time so this is just an unformated string type.