### PR TITLE
Preserve newlines in docstring description

### DIFF
--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -343,7 +343,7 @@ fn extract_fn_documentation(
         }
     };
     let summary = none_if_empty(summary.into_iter().collect::<String>().trim());
-    let description = none_if_empty(description.into_iter().collect::<String>().trim());
+    let description = none_if_empty(description.join("\n").trim());
     (summary, description)
 }
 


### PR DESCRIPTION
Hello!

This small change adds "\n" at the end of every line in description gathered from docstring. This allows to display markdown when using swagger.

Whereas this works perfectly for me, I'm not sure about other use-cases. For example if in future paperclip will support YAML format then this could potentially break something.

If you have any advice let me know and I'll try to amend this.