### PR TITLE
Support actix-files 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ v2 = ["paperclip-macros/v2", "paperclip-core/v2"]
 # Features for implementing traits for dependencies.
 actix-multipart = ["paperclip-core/actix-multipart"]
 actix-session = ["paperclip-core/actix-session"]
+actix-files = ["paperclip-core/actix-files"]
 chrono = ["paperclip-core/chrono"]
 rust_decimal = ["paperclip-core/rust_decimal"]
 uuid = ["paperclip-core/uuid"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ actix-web2 = { version = "2", optional = true, default-features = false, package
 actix-web3 = { version = "3", optional = true, default-features = false, package = "actix-web" }
 actix-multipart = { version = "0", optional = true }
 actix-session = { version = "0", optional = true }
+actix-files = {version = "0", optional = true}
 chrono = { version = "0", optional = true }
 heck = { version = "0.3", optional = true }
 once_cell = "1.4"

--- a/core/src/v2/actix.rs
+++ b/core/src/v2/actix.rs
@@ -290,6 +290,11 @@ impl OperationModifier for actix_session::Session {
     fn update_definitions(_map: &mut BTreeMap<String, DefaultSchemaRaw>) {}
 }
 
+#[cfg(feature = "actix-files")]
+impl OperationModifier for actix_files::NamedFile {
+    fn update_definitions(_map: &mut BTreeMap<String, DefaultSchemaRaw>) {}
+}
+
 macro_rules! impl_param_extractor ({ $ty:ty => $container:ident } => {
     #[cfg(feature = "nightly")]
     impl<T> Apiv2Schema for $ty {

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -194,6 +194,12 @@ impl_type_simple!(
 );
 #[cfg(feature = "actix-session")]
 impl_type_simple!(actix_session::Session);
+#[cfg(feature = "actix-files")]
+impl_type_simple!(
+    actix_files::NamedFile,
+    DataType::File,
+    DataTypeFormat::Binary
+);
 #[cfg(feature = "chrono")]
 impl_type_simple!(
     chrono::NaiveDateTime,


### PR DESCRIPTION
Commit adds support for [actix-files](https://crates.io/crates/actix-files).  My API needed `NamedFile` for file download endpoints.
Btw, I noticed a [failed rustfmt build](https://travis-ci.com/github/eisberg-labs/paperclip/jobs/461684094) but on existing files on master.