### PR TITLE
Dump spec from actix configuration with spec() method on App builder

### DIFF
--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -279,6 +279,11 @@ where
         call(self, spec)
     }
 
+    // Returns the spec as a serde value. Does not continue to build the application.
+    pub fn spec(self) -> serde_json::Value {
+        serde_json::to_value(&*self.spec.read()).expect("generating json spec")
+    }
+
     /// Builds and returns the `actix_web::App`.
     pub fn build(self) -> actix_web::App<T, B> {
         self.inner.expect("missing app?")


### PR DESCRIPTION
closes #279 

This allows you to return a serde_json::Value from the app builder, allowing you to dump a definition at any time.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>