### PR TITLE
Provide the --no-root flag to the CLI which allows the crate to be embedded

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -86,7 +86,7 @@ fn parse_args_and_run() -> Result<(), Error> {
         meta.version = opt.version;
     }
 
-    meta.root = !opt.no_root;
+    meta.no_root = opt.no_root;
 
     state.set_meta(meta);
     let emitter = DefaultEmitter::from(state);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -47,6 +47,9 @@ struct Opt {
     /// Emit CLI target instead.
     #[structopt(long = "cli")]
     cli: bool,
+    /// Do not make the crate a root crate.
+    #[structopt(long = "no-root")]
+    no_root: bool,
     /// Name of the crate. If this is not specified, then the name of the
     /// working directory is assumed to be crate name.
     #[structopt(long = "name")]
@@ -82,6 +85,8 @@ fn parse_args_and_run() -> Result<(), Error> {
     if opt.version.is_some() {
         meta.version = opt.version;
     }
+
+    meta.root = !opt.no_root;
 
     state.set_meta(meta);
     let emitter = DefaultEmitter::from(state);

--- a/src/build/manifest.hbs
+++ b/src/build/manifest.hbs
@@ -39,6 +39,6 @@ reqwest = \{ version = "0.10", features = ["stream", "json", "native-tls"] }
 tokio = \{ version = "0.3", features = ["fs", "io-util"] }
 reqwest = \{ version = "0.10", features = ["stream", "json"] }
 {{ endif }}
-{{ if root -}}
+{{ if not no_root -}}
 [workspace]
 {{- endif }}

--- a/src/build/manifest.hbs
+++ b/src/build/manifest.hbs
@@ -39,4 +39,6 @@ reqwest = \{ version = "0.10", features = ["stream", "json", "native-tls"] }
 tokio = \{ version = "0.3", features = ["fs", "io-util"] }
 reqwest = \{ version = "0.10", features = ["stream", "json"] }
 {{ endif }}
+{{ if root -}}
 [workspace]
+{{- endif }}

--- a/src/v2/codegen/mod.rs
+++ b/src/v2/codegen/mod.rs
@@ -65,7 +65,7 @@ pub struct CrateMeta {
     /// Whether we're planning to emit a lib, app or module.
     pub mode: EmitMode,
     /// Whether or not to make this a root crate.
-    pub root: bool,
+    pub no_root: bool,
     // Marker to avoid potential breakage when more public fields come in.
     _marker: (),
 }

--- a/src/v2/codegen/mod.rs
+++ b/src/v2/codegen/mod.rs
@@ -64,6 +64,8 @@ pub struct CrateMeta {
     pub authors: Option<Vec<String>>,
     /// Whether we're planning to emit a lib, app or module.
     pub mode: EmitMode,
+    /// Whether or not to make this a root crate.
+    pub root: bool,
     // Marker to avoid potential breakage when more public fields come in.
     _marker: (),
 }

--- a/src/v2/codegen/state.rs
+++ b/src/v2/codegen/state.rs
@@ -374,6 +374,15 @@ pub mod util {
             .unwrap_or(false))
     }
 
+    fn root(&self) -> Result<bool, Error> {
+        Ok(self
+            .infer_crate_meta()?
+            .borrow()
+            .as_ref()
+            .map(|m| m.root)
+            .unwrap_or(true))
+    }
+
     /// Normalized module prefix used by codegen.
     fn normalized_mod_prefix(&self) -> String {
         format!("{}::", self.mod_prefix.trim_matches(':'))
@@ -420,6 +429,7 @@ impl EmitterState {
     fn create_manifest(&self) -> Result<(), Error> {
         let mut man_path = self.root_module_path();
         let is_cli = self.is_cli()?;
+        let root = self.root()?;
         man_path.set_file_name("Cargo.toml");
 
         let cm = self.infer_crate_meta()?;
@@ -437,6 +447,7 @@ impl EmitterState {
                     version: &format!("{:?}", meta.version.as_ref().unwrap()),
                     authors: &format!("{:?}", meta.authors.as_ref().unwrap()),
                     is_cli,
+                    root,
                 },
             )?;
 
@@ -572,6 +583,7 @@ struct ManifestContext<'a> {
     version: &'a str,
     authors: &'a str,
     is_cli: bool,
+    root: bool,
 }
 
 #[derive(serde::Serialize)]

--- a/src/v2/codegen/state.rs
+++ b/src/v2/codegen/state.rs
@@ -374,12 +374,12 @@ pub mod util {
             .unwrap_or(false))
     }
 
-    fn root(&self) -> Result<bool, Error> {
+    fn no_root(&self) -> Result<bool, Error> {
         Ok(self
             .infer_crate_meta()?
             .borrow()
             .as_ref()
-            .map(|m| m.root)
+            .map(|m| m.no_root)
             .unwrap_or(true))
     }
 
@@ -429,7 +429,7 @@ impl EmitterState {
     fn create_manifest(&self) -> Result<(), Error> {
         let mut man_path = self.root_module_path();
         let is_cli = self.is_cli()?;
-        let root = self.root()?;
+        let no_root = self.no_root()?;
         man_path.set_file_name("Cargo.toml");
 
         let cm = self.infer_crate_meta()?;
@@ -447,7 +447,7 @@ impl EmitterState {
                     version: &format!("{:?}", meta.version.as_ref().unwrap()),
                     authors: &format!("{:?}", meta.authors.as_ref().unwrap()),
                     is_cli,
-                    root,
+                    no_root,
                 },
             )?;
 
@@ -583,7 +583,7 @@ struct ManifestContext<'a> {
     version: &'a str,
     authors: &'a str,
     is_cli: bool,
-    root: bool,
+    no_root: bool,
 }
 
 #[derive(serde::Serialize)]

--- a/tests/snapshots/test_codegen__tests__test_pet__no_root__Cargo.toml.snap
+++ b/tests/snapshots/test_codegen__tests__test_pet__no_root__Cargo.toml.snap
@@ -1,0 +1,35 @@
+---
+source: tests/test_codegen.rs
+expression: data
+---
+[package]
+name = "no_root"
+version = "0.1.0"
+authors = ["Me <me@example.com>"]
+edition = "2018"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+async-trait = "0.1"
+bytes = "0.5"
+thiserror = "1.0"
+futures = "0.3"
+http = "0.2"
+lazy_static = "1.4"
+log = "0.4"
+mime = { git = "https://github.com/hyperium/mime" }
+mime_guess = "2.0"
+parking_lot = "0.11"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.8"
+tokio-util = { version = "0.4", features = ["codec"] }
+url = "2.1"
+
+tokio = { version = "0.3", features = ["fs", "io-util"] }
+reqwest = { version = "0.10", features = ["stream", "json"] }
+
+
+

--- a/tests/test_codegen.rs
+++ b/tests/test_codegen.rs
@@ -25,7 +25,6 @@ static CODEGEN_PET_LIB: Lazy<()> = Lazy::new(|| {
     let mut meta = CrateMeta::default();
     meta.authors = Some(vec!["Me <me@example.com>".into()]);
     meta.mode = EmitMode::Crate;
-    meta.root = true;
     state.set_meta(meta);
 
     let emitter = DefaultEmitter::from(state);
@@ -38,7 +37,7 @@ static CODEGEN_PET_LIB_NO_ROOT: Lazy<()> = Lazy::new(|| {
     let mut meta = CrateMeta::default();
     meta.authors = Some(vec!["Me <me@example.com>".into()]);
     meta.mode = EmitMode::Crate;
-    meta.root = false;
+    meta.no_root = true;
     state.set_meta(meta);
 
     let emitter = DefaultEmitter::from(state);
@@ -51,7 +50,6 @@ static CODEGEN_PET_CLI: Lazy<()> = Lazy::new(|| {
     let mut meta = CrateMeta::default();
     meta.authors = Some(vec!["Me <me@example.com>".into()]);
     meta.mode = EmitMode::App;
-    meta.root = true;
     state.set_meta(meta);
 
     let emitter = DefaultEmitter::from(state);
@@ -78,7 +76,6 @@ static CODEGEN_K8S_CLI: Lazy<()> = Lazy::new(|| {
     meta.version = Some("0.0.0".into());
     meta.authors = Some(vec!["Me <me@example.com>".into()]);
     meta.mode = EmitMode::App;
-    meta.root = true;
     state.set_meta(meta);
 
     let emitter = DefaultEmitter::from(state);

--- a/tests/test_codegen.rs
+++ b/tests/test_codegen.rs
@@ -25,6 +25,7 @@ static CODEGEN_PET_LIB: Lazy<()> = Lazy::new(|| {
     let mut meta = CrateMeta::default();
     meta.authors = Some(vec!["Me <me@example.com>".into()]);
     meta.mode = EmitMode::Crate;
+    meta.root = true;
     state.set_meta(meta);
 
     let emitter = DefaultEmitter::from(state);
@@ -37,6 +38,7 @@ static CODEGEN_PET_CLI: Lazy<()> = Lazy::new(|| {
     let mut meta = CrateMeta::default();
     meta.authors = Some(vec!["Me <me@example.com>".into()]);
     meta.mode = EmitMode::App;
+    meta.root = true;
     state.set_meta(meta);
 
     let emitter = DefaultEmitter::from(state);
@@ -63,6 +65,7 @@ static CODEGEN_K8S_CLI: Lazy<()> = Lazy::new(|| {
     meta.version = Some("0.0.0".into());
     meta.authors = Some(vec!["Me <me@example.com>".into()]);
     meta.mode = EmitMode::App;
+    meta.root = true;
     state.set_meta(meta);
 
     let emitter = DefaultEmitter::from(state);

--- a/tests/test_codegen.rs
+++ b/tests/test_codegen.rs
@@ -31,6 +31,19 @@ static CODEGEN_PET_LIB: Lazy<()> = Lazy::new(|| {
     let emitter = DefaultEmitter::from(state);
     emitter.generate(&PET_SCHEMA).expect("codegen");
 });
+static CODEGEN_PET_LIB_NO_ROOT: Lazy<()> = Lazy::new(|| {
+    let mut state = EmitterState::default();
+    state.working_dir = ROOT.clone();
+    state.working_dir.push("tests/test_pet/no_root");
+    let mut meta = CrateMeta::default();
+    meta.authors = Some(vec!["Me <me@example.com>".into()]);
+    meta.mode = EmitMode::Crate;
+    meta.root = false;
+    state.set_meta(meta);
+
+    let emitter = DefaultEmitter::from(state);
+    emitter.generate(&PET_SCHEMA).expect("codegen");
+});
 static CODEGEN_PET_CLI: Lazy<()> = Lazy::new(|| {
     let mut state = EmitterState::default();
     state.working_dir = (&*ROOT).into();
@@ -94,6 +107,7 @@ static CODEGEN: Lazy<()> = Lazy::new(|| {
         .filter(Some("paperclip"), log::LevelFilter::Info)
         .init();
     Lazy::force(&CODEGEN_PET_LIB);
+    Lazy::force(&CODEGEN_PET_LIB_NO_ROOT);
     Lazy::force(&CODEGEN_PET_CLI);
     Lazy::force(&CODEGEN_K8S_LIB);
     Lazy::force(&CODEGEN_K8S_CLI);
@@ -113,6 +127,11 @@ mod tests_pet {
     #[test]
     fn test_lib_root() {
         assert_file("tests/test_pet/lib.rs");
+    }
+
+    #[test]
+    fn test_no_root_manifest() {
+        assert_file("tests/test_pet/no_root/Cargo.toml");
     }
 
     #[test]


### PR DESCRIPTION
This omits the workspace definition, allowing it to be embedded in other
repositories.

hope this patch is welcome. seems to be doing what i need locally, but I may have missed something.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>