### PR TITLE
fix(tuples): make doc work in tuple struct path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Optional type aliases like `type Email = Option<String>` will not be added to the `required` fields.
+- Actix plugin: Path tuples now inherit field names and descriptions from doc comments
 
 ## [0.5.0] - 2020-11-28
 ### Added

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -169,12 +169,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+                Config = (),
+                Request = ServiceRequest,
+                Response = ServiceResponse,
+                Error = Error,
+                InitError = (),
+            > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.take().map(|a| a.default_service(f));

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -59,12 +59,12 @@ impl Resource {
 impl<T> HttpServiceFactory for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
-        Config = (),
-        Request = ServiceRequest,
-        Response = ServiceResponse,
-        Error = Error,
-        InitError = (),
-    > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
 {
     fn register(self, config: &mut AppService) {
         self.inner.register(config)
@@ -74,12 +74,12 @@ where
 impl<T> IntoServiceFactory<T> for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
-        Config = (),
-        Request = ServiceRequest,
-        Response = ServiceResponse,
-        Error = Error,
-        InitError = (),
-    > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
 {
     fn into_factory(self) -> T {
         self.inner.into_factory()
@@ -242,12 +242,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+                Config = (),
+                Request = ServiceRequest,
+                Response = ServiceResponse,
+                Error = Error,
+                InitError = (),
+            > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.default_service(f);
@@ -302,12 +302,12 @@ impl Scope {
 impl<T> HttpServiceFactory for Scope<actix_web::Scope<T>>
 where
     T: ServiceFactory<
-        Config = (),
-        Request = ServiceRequest,
-        Response = ServiceResponse,
-        Error = Error,
-        InitError = (),
-    > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
 {
     fn register(self, config: &mut AppService) {
         if let Some(s) = self.inner {
@@ -382,12 +382,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+                Config = (),
+                Request = ServiceRequest,
+                Response = ServiceResponse,
+                Error = Error,
+                InitError = (),
+            > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.map(|s| s.default_service(f));


### PR DESCRIPTION
Add missing schema to unnamed structs with >1 element.
Fix issue with unnamed structs of 1 element caused by:
6429ef4
Fix usage of structs with Path with tuples: Path<(A,B,C)>

Unnamed struct element now get named starting from 0,1..... so that we
can keep the list of properties, though they should not really be used
anywhere else than a Path.