### PR TITLE
feat(macro): add macro helpers for method routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add support for actix-web-macros methods routing [PR#289](https://github.com/wafflespeanut/paperclip/pull/289)
 
 ### Changed
 

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -5,9 +5,10 @@ use heck::*;
 use http::StatusCode;
 use lazy_static::lazy_static;
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use strum_macros::EnumString;
 use syn::{
+    parse_macro_input,
     punctuated::{Pair, Punctuated},
     spanned::Spanned,
     Attribute, Data, DataEnum, DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed, FnArg,
@@ -1115,4 +1116,147 @@ impl SerdeFlatten {
 
         false
     }
+}
+
+macro_rules! doc_comment {
+    ($x:expr; $($tt:tt)*) => {
+        #[doc = $x]
+        $($tt)*
+    };
+}
+
+#[cfg(feature = "actix")]
+impl super::Method {
+    fn handler_uri(attr: TokenStream) -> TokenStream {
+        let attr = parse_macro_input!(attr as syn::AttributeArgs);
+        attr.first().into_token_stream().into()
+    }
+    fn handler_name(item: TokenStream) -> syn::Result<syn::Ident> {
+        let handler: ItemFn = syn::parse(item)?;
+        Ok(handler.sig.ident)
+    }
+    pub(crate) fn generate(
+        &self,
+        attr: TokenStream,
+        item: TokenStream,
+    ) -> syn::Result<proc_macro2::TokenStream> {
+        let uri: proc_macro2::TokenStream = Self::handler_uri(attr).into();
+        let handler_name = Self::handler_name(item.clone())?;
+        let handler_fn: proc_macro2::TokenStream = item.into();
+        let method: proc_macro2::TokenStream = self.method().parse()?;
+        let variant: proc_macro2::TokenStream = self.variant().parse()?;
+        let handler_name_str = handler_name.to_string();
+
+        Ok(quote! {
+            #[allow(non_camel_case_types, missing_docs)]
+            pub struct #handler_name;
+
+            impl #handler_name {
+                fn resource() -> paperclip::actix::web::Resource {
+                    #handler_fn
+                    paperclip::actix::web::Resource::new(#uri)
+                        .name(#handler_name_str)
+                        .guard(actix_web::guard::#variant())
+                        .route(paperclip::actix::web::#method().to(#handler_name))
+                }
+            }
+
+            impl actix_web::dev::HttpServiceFactory for #handler_name {
+                fn register(self, config: &mut actix_web::dev::AppService) {
+                    Self::resource().register(config);
+                }
+            }
+
+            impl paperclip::actix::Mountable for #handler_name {
+                fn path(&self) -> &str {
+                    #uri
+                }
+
+                fn operations(
+                    &mut self,
+                ) -> std::collections::BTreeMap<
+                    paperclip::v2::models::HttpMethod,
+                    paperclip::v2::models::DefaultOperationRaw,
+                > {
+                    Self::resource().operations()
+                }
+
+                fn definitions(
+                    &mut self,
+                ) -> std::collections::BTreeMap<
+                    String,
+                    paperclip::v2::models::DefaultSchemaRaw,
+                > {
+                    Self::resource().definitions()
+                }
+
+                fn security_definitions(
+                    &mut self,
+                ) -> std::collections::BTreeMap<String, paperclip::v2::models::SecurityScheme>
+                {
+                    Self::resource().security_definitions()
+                }
+            }
+        })
+    }
+}
+
+#[macro_use]
+macro_rules! rest_methods {
+    (
+        $($variant:ident, $method:ident, )+
+    ) => {
+        /// All available Rest methods
+        #[derive(Debug, PartialEq, Eq, Hash)]
+        pub(crate) enum Method {
+            $(
+                $variant,
+            )+
+        }
+
+        impl Method {
+            fn method(&self) -> &'static str {
+                match self {
+                    $(Self::$variant => stringify!($method),)+
+                }
+            }
+            fn variant(&self) -> &'static str {
+                match self {
+                    $(Self::$variant => stringify!($variant),)+
+                }
+            }
+        }
+
+        $(doc_comment! {
+            concat!("
+Creates route handler with `paperclip::actix::web::Resource", "`.
+In order to control the output type and status codes the return value/response must implement the
+trait actix_web::Responder.
+
+# Syntax
+```text
+#[", stringify!($method), r#"("path"[, attributes])]
+```
+
+# Attributes
+- `"path"` - Raw literal string with path for which to register handler.
+
+# Example
+
+/// use paperclip::actix::web::Json;
+/// use paperclip_macros::"#, stringify!($method), ";
+/// #[", stringify!($method), r#"("/")]
+/// async fn example() {
+/// }
+"#);
+            #[cfg(feature = "actix")]
+            #[proc_macro_attribute]
+            pub fn $method(attr: TokenStream, item: TokenStream) -> TokenStream {
+                match Method::$variant.generate(attr, item) {
+                    Ok(v) => v.into(),
+                    Err(e) => e.to_compile_error().into(),
+                }
+            }
+        })+
+    };
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,6 +10,7 @@ extern crate proc_macro;
 extern crate proc_macro_error;
 
 #[cfg(feature = "actix")]
+#[macro_use]
 mod actix;
 #[cfg(feature = "v2")]
 mod core;
@@ -107,4 +108,12 @@ fn parse_input_attrs(ts: TokenStream) -> MacroAttribute {
         })
         .ok()
         .unwrap_or_default()
+}
+
+#[cfg(feature = "actix")]
+rest_methods! {
+    Get,    get,
+    Post,   post,
+    Put,    put,
+    Delete, delete,
 }

--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -6,7 +6,9 @@ extern crate actix_web3 as actix_web;
 pub mod web;
 
 pub use self::web::{Resource, Route, Scope};
-pub use paperclip_macros::{api_v2_errors, api_v2_operation, Apiv2Schema, Apiv2Security};
+pub use paperclip_macros::{
+    api_v2_errors, api_v2_operation, delete, get, post, put, Apiv2Schema, Apiv2Security,
+};
 
 use self::web::{RouteWrapper, ServiceConfig};
 use actix_service::ServiceFactory;
@@ -169,12 +171,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+                Config = (),
+                Request = ServiceRequest,
+                Response = ServiceResponse,
+                Error = Error,
+                InitError = (),
+            > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.take().map(|a| a.default_service(f));

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -59,12 +59,12 @@ impl Resource {
 impl<T> HttpServiceFactory for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
-        Config = (),
-        Request = ServiceRequest,
-        Response = ServiceResponse,
-        Error = Error,
-        InitError = (),
-    > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
 {
     fn register(self, config: &mut AppService) {
         self.inner.register(config)
@@ -74,12 +74,12 @@ where
 impl<T> IntoServiceFactory<T> for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
-        Config = (),
-        Request = ServiceRequest,
-        Response = ServiceResponse,
-        Error = Error,
-        InitError = (),
-    > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
 {
     fn into_factory(self) -> T {
         self.inner.into_factory()
@@ -242,12 +242,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+                Config = (),
+                Request = ServiceRequest,
+                Response = ServiceResponse,
+                Error = Error,
+                InitError = (),
+            > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.default_service(f);
@@ -302,12 +302,12 @@ impl Scope {
 impl<T> HttpServiceFactory for Scope<actix_web::Scope<T>>
 where
     T: ServiceFactory<
-        Config = (),
-        Request = ServiceRequest,
-        Response = ServiceResponse,
-        Error = Error,
-        InitError = (),
-    > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
 {
     fn register(self, config: &mut AppService) {
         if let Some(s) = self.inner {
@@ -382,12 +382,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+                Config = (),
+                Request = ServiceRequest,
+                Response = ServiceResponse,
+                Error = Error,
+                InitError = (),
+            > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.map(|s| s.default_service(f));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ pub mod actix {
     //! Plugin types, traits and macros for actix-web framework.
 
     pub use paperclip_actix::{
-        api_v2_errors, api_v2_operation, web, Apiv2Schema, Apiv2Security, App, Mountable,
-        OpenApiExt,
+        api_v2_errors, api_v2_operation, delete, get, post, put, web, Apiv2Schema, Apiv2Security,
+        App, Mountable, OpenApiExt,
     };
     pub use paperclip_core::v2::{
         AcceptedJson, CreatedJson, NoContent, OperationModifier, ResponderWrapper, ResponseWrapper,


### PR DESCRIPTION
Add macro helpers for routing methods get, put, post, delete:
these are based on the actix_web macros and intended to be facilitate
use paperclip on actix_web code which already makes use of the original
macros from actix_web:
https://docs.rs/actix-web-macros/0.1.0/actix_web_macros/