### PR TITLE
fix(doc): missing documentation on types

### DIFF
--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -150,6 +150,7 @@ fn test_simple_app() {
                   "info":{"title":"","version":""},
                   "definitions": {
                     "Pet": {
+                      "description":"Pets are awesome!",
                       "properties": {
                         "class": {
                           "enum": ["dog", "cat", "other"],
@@ -1236,6 +1237,7 @@ fn test_serde_flatten() {
                 json!({
                     "definitions": {
                         "Images": {
+                          "description": "Images response with paging information embedded",
                           "properties": {
                             "data": {
                               "items": {
@@ -2405,6 +2407,7 @@ fn test_errors_app() {
                   "info":{"title":"","version":""},
                   "definitions": {
                     "Pet": {
+                      "description": "Pets are awesome!",
                       "properties": {
                         "class": {
                           "enum": ["dog", "cat", "other"],
@@ -2567,6 +2570,7 @@ fn test_security_app() {
                   "info":{"title":"","version":""},
                   "definitions": {
                     "Pet": {
+                      "description": "Pets are awesome!",
                       "properties": {
                         "class": {
                           "enum": ["dog", "cat", "other"],


### PR DESCRIPTION
Add missing documentation to struct definitions.
Updated tests.

Resolves  #290