### PR TITLE
support actix-files static file serving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ v2 = ["paperclip-macros/v2", "paperclip-core/v2"]
 # Features for implementing traits for dependencies.
 actix-multipart = ["paperclip-core/actix-multipart"]
 actix-session = ["paperclip-core/actix-session"]
-actix-files = ["paperclip-core/actix-files"]
+actix-files = ["paperclip-core/actix-files", "paperclip-actix/actix-files"]
 chrono = ["paperclip-core/chrono"]
 rust_decimal = ["paperclip-core/rust_decimal"]
 uuid = ["paperclip-core/uuid"]

--- a/plugins/actix-web/Cargo.toml
+++ b/plugins/actix-web/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/wafflespeanut/paperclip"
 
 [dependencies]
 futures = "0.3"
+actix-files = {version = "0", optional = true}
 actix-service = "1.0"
 actix-web2 = { version = "2", default-features = false, optional = true, package = "actix-web" }
 actix-web3 = { version = "3", default-features = false, optional = true, package = "actix-web" }

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -104,6 +104,25 @@ impl<T> Mountable for Resource<T> {
     }
 }
 
+#[cfg(feature = "actix-files")]
+impl Mountable for actix_files::Files {
+    fn path(&self) -> &str {
+        ""
+    }
+
+    fn operations(&mut self) -> BTreeMap<HttpMethod, DefaultOperationRaw> {
+        BTreeMap::new()
+    }
+
+    fn definitions(&mut self) -> BTreeMap<String, DefaultSchemaRaw> {
+        BTreeMap::new()
+    }
+
+    fn security_definitions(&mut self) -> BTreeMap<String, SecurityScheme> {
+        BTreeMap::new()
+    }
+}
+
 impl<T> Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<


### PR DESCRIPTION
This PR adds support for actix_files::Files.

It will just make it compile and won't add any Swagger definitions, since static files that are served should not have any impact on the REST API.