### PR TITLE
fix(tests): PR#289 needs an update after PR#297

### DIFF
--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -2726,6 +2726,7 @@ fn test_method_macro() {
                 json!({
                     "definitions": {
                         "Pet": {
+                            "description": "Pets are awesome!",
                             "properties": {
                                 "class": {
                                 "enum": ["dog", "cat", "other"],


### PR DESCRIPTION
PR#297 brought the "higher-level" descriptions to the spec which meant
 that PR#298 got "out of date" and so we need to fix the test.